### PR TITLE
fix for building on Raspberry Pi

### DIFF
--- a/src/arch/relic_arch_arm.c
+++ b/src/arch/relic_arch_arm.c
@@ -52,7 +52,7 @@
 /*============================================================================*/
 
 void arch_init(void) {
-#if __ARM_ARCH_6J__ || __ARM_ARCH_6ZK__
+ #if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__)
 	/* 
 	 * This relies on a Kernel module described in:
 	 * http://blog.regehr.org/archives/794
@@ -80,7 +80,7 @@ void arch_clean(void) {
 
 ull_t arch_cycles(void) {
 	unsigned int value = 0;
-#ifdef __ARM_ARCH_6J__ || __ARM_ARCH_6ZK__
+ #if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__)
 	asm("mrc p15, 0, %0, c15, c12, 1" : "=r"(value));	
 #elif __ARM_ARCH_7A__
 	asm("mcr p15, 0, %0, c9, c13, 0" : "=r"(value));


### PR DESCRIPTION
2 line change to get relic-toolkit to build on the Raspberry Pi (Raspbian with stock kernel) correctly
