### PR TITLE
bgn issue when plaintext equals to zero fixed

### DIFF
--- a/src/cp/relic_cp_bgn.c
+++ b/src/cp/relic_cp_bgn.c
@@ -96,6 +96,7 @@ int cp_bgn_enc1(g1_t out[2], dig_t in, bgn_t pub) {
 
 		/* Compute c0 = (ym + r)G. */
 		g1_mul_dig(out[0], pub->gy, in);
+
 		g1_mul_gen(t, r);
 		g1_add(out[0], out[0], t);
 		g1_norm(out[0], out[0]);
@@ -147,6 +148,10 @@ int cp_bgn_dec1(dig_t *out, g1_t in[2], bgn_t prv) {
 		bn_mod(r, r, n);
 		g1_mul_gen(s, r);
 		g1_copy(u, s);
+		if ( g1_is_infty(t) == 1){
+			*out = 0;
+			break;
+		} 		
 		for (i = 0; i < INT_MAX; i++) {
 			if (g1_cmp(t, u) == CMP_EQ) {
 				*out = i + 1;
@@ -155,7 +160,7 @@ int cp_bgn_dec1(dig_t *out, g1_t in[2], bgn_t prv) {
 			g1_add(u, u, s);
 			g1_norm(u, u);			
 		}
-
+		
 		if (i == INT_MAX) {
 			result = STS_ERR;
 		}
@@ -243,6 +248,11 @@ int cp_bgn_dec2(dig_t *out, g2_t in[2], bgn_t prv) {
 		bn_mod(r, r, n);
 		g2_mul_gen(s, r);
 		g2_copy(u, s);
+		
+		if ( g2_is_infty(t) == 1) {
+			*out = 0;
+			break;
+		} 		
 		for (i = 0; i < INT_MAX; i++) {
 			if (g2_cmp(t, u) == CMP_EQ) {
 				*out = i + 1;
@@ -338,6 +348,11 @@ int cp_bgn_dec(dig_t *out, gt_t in[4], bgn_t prv) {
 		gt_exp(t[1], t[1], r);
 
 		gt_copy(t[2], t[1]);
+
+		if ( gt_is_unity(t[3]) == 1) {
+			*out = 0;
+			break;
+		} 	
 		for (i = 0; i < INT_MAX; i++) {
 			if (gt_cmp(t[2], t[3]) == CMP_EQ) {
 				*out = i + 1;

--- a/test/test_cp.c
+++ b/test/test_cp.c
@@ -922,10 +922,10 @@ static int bgn(void) {
 
 		TEST_BEGIN("boneh-go-nissim encryption/decryption is correct") {
 			TEST_ASSERT(result == STS_OK, end);
-			do {
-				rand_bytes((unsigned char *)&in, sizeof(dig_t));
-				in = in % 11;
-			} while (in == 0);
+
+			rand_bytes((unsigned char *)&in, sizeof(dig_t));
+			in = in % 11;
+
 			TEST_ASSERT(cp_bgn_enc1(c, in, pub) == STS_OK, end);
 			TEST_ASSERT(cp_bgn_dec1(&out, c, prv) == STS_OK, end);
 			TEST_ASSERT(in == out, end);
@@ -935,11 +935,9 @@ static int bgn(void) {
 		} TEST_END;
 
 		TEST_BEGIN("boneh-go-nissim encryption is additively homomorphic") {
-			do {
-				rand_bytes((unsigned char *)&in, sizeof(dig_t));
-				in = in % 11;
-				out = in % 7;
-			} while (in == 0 || out == 0);
+			rand_bytes((unsigned char *)&in, sizeof(dig_t));
+			in = in % 11;
+			out = in % 7;
 			TEST_ASSERT(cp_bgn_enc1(c, in, pub) == STS_OK, end);
 			TEST_ASSERT(cp_bgn_enc1(d, out, pub) == STS_OK, end);
 			g1_add(c[0], c[0], d[0]);
@@ -959,11 +957,9 @@ static int bgn(void) {
 		} TEST_END;
 
 		TEST_BEGIN("boneh-go-nissim encryption is multiplicatively homomorphic") {
-			do {
-				rand_bytes((unsigned char *)&in, sizeof(dig_t));
-				in = in % 11;
-				out = in % 17;
-			} while (in == 0 || out == 0);
+			rand_bytes((unsigned char *)&in, sizeof(dig_t));
+			in = in % 11;
+			out = in % 17;
 			TEST_ASSERT(cp_bgn_enc1(c, in, pub) == STS_OK, end);
 			TEST_ASSERT(cp_bgn_enc2(e, out, pub) == STS_OK, end);
 			in = in * out;


### PR DESCRIPTION
The BGN decryption funcitons  cp_bgn_dec1, cp_bgn_dec2 and cp_bgn_dec didn't handle the case of an encrypted plaintext equals to zero.