### PR TITLE
Add relic-config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,8 @@ file(GLOB includes "${CMAKE_CURRENT_SOURCE_DIR}/include/low/*.h")
 install(FILES ${includes} DESTINATION include/${RELIC}/low)
 install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/" DESTINATION include/${RELIC})
 
+install(FILES relic-config.cmake DESTINATION cmake/)
+
 if(DOCUM)
 	include(cmake/doxygen.cmake)
 endif(DOCUM)

--- a/relic-config.cmake
+++ b/relic-config.cmake
@@ -1,0 +1,10 @@
+find_path(RELIC_INCLUDE_DIR relic/relic.h)
+find_library(RELIC_LIBRARY NAMES relic)
+
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(RELIC DEFAULT_MSG RELIC_INCLUDE_DIR RELIC_LIBRARY)
+
+if(RELIC_FOUND)
+	set(RELIC_LIBRARIES ${RELIC_LIBRARY})
+	set(RELIC_INCLUDE_DIRS ${RELIC_INCLUDE_DIR})
+endif()


### PR DESCRIPTION
This allows other CMake projects to automatically include Relic using `FIND_PATH(relic)`.
