### PR TITLE
Rename align define to relic_align to avoid conflicts

### DIFF
--- a/include/relic_bn.h
+++ b/include/relic_bn.h
@@ -117,7 +117,7 @@ typedef struct {
 	dig_t *dp;
 #elif ALLOC == STACK || ALLOC == AUTO
 	/** The sequence of contiguous digits that forms this integer. */
-	align dig_t dp[BN_SIZE];
+	relic_align dig_t dp[BN_SIZE];
 #endif
 } bn_st;
 

--- a/include/relic_dv.h
+++ b/include/relic_dv.h
@@ -85,7 +85,7 @@
  * Represents a temporary double-precision digit vector.
  */
 #if ALLOC == AUTO
-typedef align dig_t dv_t[DV_DIGS + PADDING(DV_BYTES)/(DIGIT / 8)];
+typedef relic_align dig_t dv_t[DV_DIGS + PADDING(DV_BYTES)/(DIGIT / 8)];
 #else
 typedef dig_t *dv_t;
 #endif

--- a/include/relic_fb.h
+++ b/include/relic_fb.h
@@ -169,7 +169,7 @@ enum {
  * Represents a binary field element.
  */
 #if ALLOC == AUTO
-typedef align dig_t fb_t[FB_DIGS + PADDING(FB_BYTES)/(FB_DIGIT / 8)];
+typedef relic_align dig_t fb_t[FB_DIGS + PADDING(FB_BYTES)/(FB_DIGIT / 8)];
 #else
 typedef dig_t *fb_t;
 #endif
@@ -177,7 +177,7 @@ typedef dig_t *fb_t;
 /**
  * Represents a binary field element with automatic memory allocation.
  */
-typedef align dig_t fb_st[FB_DIGS + PADDING(FB_BYTES)/(FB_DIGIT / 8)];
+typedef relic_align dig_t fb_st[FB_DIGS + PADDING(FB_BYTES)/(FB_DIGIT / 8)];
 
 /*============================================================================*/
 /* Macro definitions                                                          */

--- a/include/relic_fp.h
+++ b/include/relic_fp.h
@@ -155,7 +155,7 @@ enum {
  * stored in the first positions of the vector.
  */
 #if ALLOC == AUTO
-typedef align dig_t fp_t[FP_DIGS + PADDING(FP_BYTES)/(FP_DIGIT / 8)];
+typedef relic_align dig_t fp_t[FP_DIGS + PADDING(FP_BYTES)/(FP_DIGIT / 8)];
 #else
 typedef dig_t *fp_t;
 #endif
@@ -163,7 +163,7 @@ typedef dig_t *fp_t;
 /**
  * Represents a prime field element with automatic memory allocation.
  */
-typedef align dig_t fp_st[FP_DIGS + PADDING(FP_BYTES)/(FP_DIGIT / 8)];
+typedef relic_align dig_t fp_st[FP_DIGS + PADDING(FP_BYTES)/(FP_DIGIT / 8)];
 
 /*============================================================================*/
 /* Macro definitions                                                          */

--- a/include/relic_pool.h
+++ b/include/relic_pool.h
@@ -75,7 +75,7 @@ typedef struct {
 	/** Indicates if this pool element is being used. */
 	int state;
 	/** The pool element. The extra digit stores the pool position. */
-	align dig_t elem[DV_DIGS + 1];
+	relic_align dig_t elem[DV_DIGS + 1];
 } pool_t;
 
 /*============================================================================*/

--- a/include/relic_types.h
+++ b/include/relic_types.h
@@ -129,9 +129,9 @@ typedef unsigned long long ull_t;
  * Specification for aligned variables.
  */
 #if ALIGN > 1
-#define align 			__attribute__ ((aligned (ALIGN)))
+#define relic_align 			__attribute__ ((aligned (ALIGN)))
 #else
-#define align 			/* empty*/
+#define relic_align 			/* empty*/
 #endif
 
 /**

--- a/src/low/avr-asm-158/relic_fp_mul_low.c
+++ b/src/low/avr-asm-158/relic_fp_mul_low.c
@@ -76,7 +76,7 @@ dig_t fp_mula_low(dig_t *c, const dig_t *a, dig_t digit) {
 }
 
 void fp_mulm_low(dig_t *c, const dig_t *a, const dig_t *b) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_muln_low(t, a, b);
 	fp_rdc(c, t);

--- a/src/low/avr-asm-158/relic_fp_sqr_low.c
+++ b/src/low/avr-asm-158/relic_fp_sqr_low.c
@@ -77,7 +77,7 @@
 /*============================================================================*/
 
 void fp_sqrm_low(dig_t *c, const dig_t *a) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_sqrn_low(t, a);
 	fp_rdc(c, t);

--- a/src/low/curve2251-sse/relic_fb_mul_low_sf.c
+++ b/src/low/curve2251-sse/relic_fb_mul_low_sf.c
@@ -41,7 +41,7 @@
 
 #define INV(A,B,C,D)	D,C,B,A
 
-const align uint32_t tm[] = {
+const relic_align uint32_t tm[] = {
 	INV(0x00000000, 0x00000000, 0x00000000, 0x00000000),
 	INV(0x0F0E0D0C, 0x0B0A0908, 0x07060504, 0x03020100),
 	INV(0x1E1C1A18, 0x16141210, 0x0E0C0A08, 0x06040200),

--- a/src/low/easy/relic_fb_inv_low.c
+++ b/src/low/easy/relic_fb_inv_low.c
@@ -38,8 +38,8 @@
 
 void fb_invn_low(dig_t *c, const dig_t *a) {
 	int j, d, lu, lv, lt, l1, l2, bu, bv;
-	align dig_t _u[2 * FB_DIGS], _v[2 * FB_DIGS];
-	align dig_t _g1[2 * FB_DIGS], _g2[2 * FB_DIGS];
+	relic_align dig_t _u[2 * FB_DIGS], _v[2 * FB_DIGS];
+	relic_align dig_t _g1[2 * FB_DIGS], _g2[2 * FB_DIGS];
 	dig_t *t = NULL, *u = NULL, *v = NULL, *g1 = NULL, *g2 = NULL, carry;
 
 	dv_zero(_g1, FB_DIGS + 1);

--- a/src/low/easy/relic_fb_itr_low.c
+++ b/src/low/easy/relic_fb_itr_low.c
@@ -41,7 +41,7 @@ void fb_itrn_low(dig_t *c, const dig_t *a, dig_t *t) {
 	int i, j;
 	dig_t u, *p;
 	const dig_t *tmp;
-	align dig_t v[FB_DIGS];
+	relic_align dig_t v[FB_DIGS];
 
 	fb_zero(v);
 

--- a/src/low/easy/relic_fb_mul_low.c
+++ b/src/low/easy/relic_fb_mul_low.c
@@ -75,7 +75,7 @@ void fb_mul1_low(dig_t *c, const dig_t *a, dig_t digit) {
 }
 
 void fb_muln_low(dig_t *c, const dig_t *a, const dig_t *b) {
-	align dig_t t[16][FB_DIGS + 1];
+	relic_align dig_t t[16][FB_DIGS + 1];
 	dig_t r0, r1, r2, r4, r8, u, carry, *tmpc;
 	const dig_t *tmpa;
 	int i, j;
@@ -148,7 +148,7 @@ void fb_muln_low(dig_t *c, const dig_t *a, const dig_t *b) {
 }
 
 void fb_muld_low(dig_t *c, const dig_t *a, const dig_t *b, int size) {
-	align dig_t t[16][size + 1];
+	relic_align dig_t t[16][size + 1];
 	dig_t u, r0, r1, r2, r4, r8, *tmpc;
 	const dig_t *tmpa;
 	int i, j;
@@ -215,7 +215,7 @@ void fb_muld_low(dig_t *c, const dig_t *a, const dig_t *b, int size) {
 }
 
 void fb_mulm_low(dig_t *c, const dig_t *a, const dig_t *b) {
-	dig_t align t[2 * FB_DIGS];
+	dig_t relic_align t[2 * FB_DIGS];
 
 	fb_muln_low(t, a, b);
 	fb_rdc(c, t);

--- a/src/low/easy/relic_fb_slv_low.c
+++ b/src/low/easy/relic_fb_slv_low.c
@@ -49,7 +49,7 @@ static const dig_t table_odds[16] = {
 void fb_slvn_low(dig_t *c, const dig_t *a) {
 	int i, j, k, b, d, v[FB_BITS];
 	dig_t u, *p;
-	align dig_t s[FB_DIGS], t[FB_DIGS];
+	relic_align dig_t s[FB_DIGS], t[FB_DIGS];
 	dig_t mask;
 	const void *tab = fb_poly_get_slv();
 

--- a/src/low/easy/relic_fb_sqr_low.c
+++ b/src/low/easy/relic_fb_sqr_low.c
@@ -156,7 +156,7 @@ void fb_sqrl_low(dig_t *c, const dig_t *a) {
 }
 
 void fb_sqrm_low(dig_t *c, const dig_t *a) {
-	dig_t align t[2 * FB_DIGS];
+	dig_t relic_align t[2 * FB_DIGS];
 
 	fb_sqrl_low(t, a);
 	fb_rdc(c, t);

--- a/src/low/easy/relic_fb_srt_low.c
+++ b/src/low/easy/relic_fb_srt_low.c
@@ -50,7 +50,7 @@ static const dig_t t1[16] = {
 static void fb_srtt_low(dig_t *c, const dig_t *a, int fa) {
 	int i, j, n, h, sh, rh, lh, sa, la, ra;
 	dig_t d, d_e, d_o;
-	align dig_t t[2 * FB_DIGS] = { 0 };
+	relic_align dig_t t[2 * FB_DIGS] = { 0 };
 
 	sh = 1 + (FB_BITS >> FB_DIG_LOG);
 	h = (sh + 1) >> 1;
@@ -103,7 +103,7 @@ static void fb_srtt_low(dig_t *c, const dig_t *a, int fa) {
 static void fb_srtp_low(dig_t *c, const dig_t *a, int fa, int fb, int fc) {
 	int i, j, n, h, sh, rh, lh, sa, la, ra, sb, lb, rb, sc, lc, rc;
 	dig_t d, d_e, d_o;
-	align dig_t t[DV_DIGS] = { 0 };
+	relic_align dig_t t[DV_DIGS] = { 0 };
 
 	sh = 1 + (FB_BITS >> FB_DIG_LOG);
 	h = (sh + 1) >> 1;
@@ -173,8 +173,8 @@ static void fb_srtp_low(dig_t *c, const dig_t *a, int fa, int fb, int fc) {
 static void fb_sqrt_low(dig_t *c, const dig_t *a) {
 	int i, j, n, sh;
 	dig_t d, d_e, d_o;
-	align dig_t t[2 * FB_DIGS] = { 0 }, s[FB_DIGS + 1] = { 0 };
-	align dig_t t_e[FB_DIGS] = { 0 }, t_o[FB_DIGS] = { 0 };
+	relic_align dig_t t[2 * FB_DIGS] = { 0 }, s[FB_DIGS + 1] = { 0 };
+	relic_align dig_t t_e[FB_DIGS] = { 0 }, t_o[FB_DIGS] = { 0 };
 
 	sh = 1 + (FB_BITS >> FB_DIG_LOG);
 

--- a/src/low/easy/relic_fp_mul_low.c
+++ b/src/low/easy/relic_fp_mul_low.c
@@ -124,7 +124,7 @@ void fp_muln_low(dig_t *c, const dig_t *a, const dig_t *b) {
 }
 
 void fp_mulm_low(dig_t *c, const dig_t *a, const dig_t *b) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_muln_low(t, a, b);
 	fp_rdc(c, t);

--- a/src/low/easy/relic_fp_rdc_low.c
+++ b/src/low/easy/relic_fp_rdc_low.c
@@ -74,7 +74,7 @@
 /*============================================================================*/
 
 void fp_rdcs_low(dig_t *c, const dig_t *a, const dig_t *m) {
-	align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS], t[2 * FP_DIGS], r[FP_DIGS];
+	relic_align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS], t[2 * FP_DIGS], r[FP_DIGS];
 	const int *sform;
 	int len, first, i, j, k, b0, d0, b1, d1;
 

--- a/src/low/easy/relic_fp_sqr_low.c
+++ b/src/low/easy/relic_fp_sqr_low.c
@@ -120,7 +120,7 @@ void fp_sqrn_low(dig_t *c, const dig_t *a) {
 }
 
 void fp_sqrm_low(dig_t *c, const dig_t *a) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_sqrn_low(t, a);
 	fp_rdc(c, t);

--- a/src/low/easy/relic_fpx_mul_low.c
+++ b/src/low/easy/relic_fpx_mul_low.c
@@ -38,7 +38,7 @@
 /*============================================================================*/
 
 void fp2_muln_low(dv2_t c, fp2_t a, fp2_t b) {
-	align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
+	relic_align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
 
 	/* Karatsuba algorithm. */
 
@@ -85,7 +85,7 @@ void fp2_muln_low(dv2_t c, fp2_t a, fp2_t b) {
 }
 
 void fp2_mulc_low(dv2_t c, fp2_t a, fp2_t b) {
-	align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
+	relic_align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
 
 	/* Karatsuba algorithm. */
 
@@ -125,7 +125,7 @@ void fp2_mulc_low(dv2_t c, fp2_t a, fp2_t b) {
 }
 
 void fp2_mulm_low(fp2_t c, fp2_t a, fp2_t b) {
-	align dv2_t t;
+	relic_align dv2_t t;
 
 	dv2_null(t);
 
@@ -141,8 +141,8 @@ void fp2_mulm_low(fp2_t c, fp2_t a, fp2_t b) {
 }
 
 void fp3_muln_low(dv3_t c, fp3_t a, fp3_t b) {
-	align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS], t3[2 * FP_DIGS];
-	align dig_t t4[2 * FP_DIGS], t5[2 * FP_DIGS], t6[2 * FP_DIGS];
+	relic_align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS], t3[2 * FP_DIGS];
+	relic_align dig_t t4[2 * FP_DIGS], t5[2 * FP_DIGS], t6[2 * FP_DIGS];
 
 	/* Karatsuba algorithm. */
 

--- a/src/low/easy/relic_fpx_sqr_low.c
+++ b/src/low/easy/relic_fpx_sqr_low.c
@@ -37,7 +37,7 @@
 /*============================================================================*/
 
 void fp2_sqrn_low(dv2_t c, fp2_t a) {
-	align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
+	relic_align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
 
 	/* t0 = (a0 + a1). */
 #ifdef FP_SPACE
@@ -109,7 +109,7 @@ void fp2_sqrn_low(dv2_t c, fp2_t a) {
 }
 
 void fp2_sqrm_low(fp2_t c, fp2_t a) {
-	align dv2_t t;
+	relic_align dv2_t t;
 
 	dv2_null(t);
 
@@ -125,8 +125,8 @@ void fp2_sqrm_low(fp2_t c, fp2_t a) {
 }
 
 void fp3_sqrn_low(dv3_t c, fp3_t a) {
-	align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
-	align dig_t t3[2 * FP_DIGS], t4[2 * FP_DIGS], t5[2 * FP_DIGS];
+	relic_align dig_t t0[2 * FP_DIGS], t1[2 * FP_DIGS], t2[2 * FP_DIGS];
+	relic_align dig_t t3[2 * FP_DIGS], t4[2 * FP_DIGS], t5[2 * FP_DIGS];
 
 	/* t0 = a_0^2. */
 	fp_sqrn_low(t0, a[0]);
@@ -181,7 +181,7 @@ void fp3_sqrn_low(dv3_t c, fp3_t a) {
 }
 
 void fp3_sqrm_low(fp3_t c, fp3_t a) {
-	align dv3_t t;
+	relic_align dv3_t t;
 
 	dv3_null(t);
 

--- a/src/low/gmp/relic_fp_mul_low.c
+++ b/src/low/gmp/relic_fp_mul_low.c
@@ -50,7 +50,7 @@ void fp_muln_low(dig_t *c, const dig_t *a, const dig_t *b) {
 }
 
 void fp_mulm_low(dig_t *c, const dig_t *a, const dig_t *b) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_muln_low(t, a, b);
 	fp_rdc(c, t);

--- a/src/low/gmp/relic_fp_sqr_low.c
+++ b/src/low/gmp/relic_fp_sqr_low.c
@@ -42,7 +42,7 @@ void fp_sqrn_low(dig_t *c, const dig_t *a) {
 }
 
 void fp_sqrm_low(dig_t *c, const dig_t *a) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_sqrn_low(t, a);
 	fp_rdc(c, t);

--- a/src/low/msp-asm/relic_fb_mul_low.c
+++ b/src/low/msp-asm/relic_fb_mul_low.c
@@ -225,7 +225,7 @@ void fb_muld_low(dig_t *c, const dig_t *a, const dig_t *b, int size) {
 }
 
 void fb_mulm_low(dig_t *c, const dig_t *a, const dig_t *b) {
-	dig_t align t[2 * FB_DIGS];
+	dig_t relic_align t[2 * FB_DIGS];
 
 	fb_muln_low(t, a, b);
 	fb_rdc(c, t);

--- a/src/low/x64-asm-254/relic_fp_sqr_low.c
+++ b/src/low/x64-asm-254/relic_fp_sqr_low.c
@@ -36,7 +36,7 @@
 /*============================================================================*/
 
 void fp_sqrm_low(dig_t *c, const dig_t *a) {
-	dig_t align t[2 * FP_DIGS];
+	dig_t relic_align t[2 * FP_DIGS];
 
 	fp_sqrn_low(t, a);
 	fp_rdc(c, t);

--- a/src/low/x64-asm-382/relic_fp_rdc_low.c
+++ b/src/low/x64-asm-382/relic_fp_rdc_low.c
@@ -40,8 +40,8 @@
 /*============================================================================*/
 
 void fp_rdcs_low(dig_t *c, const dig_t *a, const dig_t *m) {
-	align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS];
-	align dig_t _r[2 * FP_DIGS], r[2 * FP_DIGS], t[2 * FP_DIGS];
+	relic_align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS];
+	relic_align dig_t _r[2 * FP_DIGS], r[2 * FP_DIGS], t[2 * FP_DIGS];
 	const int *sform;
 	int len, first, i, j, b0, d0, b1, d1;
 	dig_t carry;

--- a/src/low/x64-asm-455/relic_fp_inv_low.c
+++ b/src/low/x64-asm-455/relic_fp_inv_low.c
@@ -41,7 +41,7 @@
 
 void fp_invn_low(dig_t *c, const dig_t *a) {
 	mp_size_t cn;
-	align dig_t s[FP_DIGS], t[2 * FP_DIGS], u[FP_DIGS + 1];
+	relic_align dig_t s[FP_DIGS], t[2 * FP_DIGS], u[FP_DIGS + 1];
 
 #if FP_RDC == MONTY
 	dv_zero(t + FP_DIGS, FP_DIGS);

--- a/src/low/x64-asm-455/relic_fp_rdc_low.c
+++ b/src/low/x64-asm-455/relic_fp_rdc_low.c
@@ -40,8 +40,8 @@
 /*============================================================================*/
 
 void fp_rdcs_low(dig_t *c, const dig_t *a, const dig_t *m) {
-	align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS];
-	align dig_t _r[2 * FP_DIGS], r[2 * FP_DIGS], t[2 * FP_DIGS];
+	relic_align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS];
+	relic_align dig_t _r[2 * FP_DIGS], r[2 * FP_DIGS], t[2 * FP_DIGS];
 	const int *sform;
 	int len, first, i, j, b0, d0, b1, d1;
 	dig_t carry;

--- a/src/low/x64-asm-638/relic_fp_inv_low.c
+++ b/src/low/x64-asm-638/relic_fp_inv_low.c
@@ -41,7 +41,7 @@
 
 void fp_invn_low(dig_t *c, const dig_t *a) {
 	mp_size_t cn;
-	align dig_t s[FP_DIGS], t[2 * FP_DIGS], u[FP_DIGS + 1];
+	relic_align dig_t s[FP_DIGS], t[2 * FP_DIGS], u[FP_DIGS + 1];
 
 #if FP_RDC == MONTY
 	dv_zero(t + FP_DIGS, FP_DIGS);

--- a/src/low/x64-asm-638/relic_fp_rdc_low.c
+++ b/src/low/x64-asm-638/relic_fp_rdc_low.c
@@ -38,7 +38,7 @@
 /*============================================================================*/
 
 void fp_rdcs_low(dig_t *c, const dig_t *a, const dig_t *m) {
-	align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS], t[2 * FP_DIGS], r[FP_DIGS];
+	relic_align dig_t q[2 * FP_DIGS], _q[2 * FP_DIGS], t[2 * FP_DIGS], r[FP_DIGS];
 	const int *sform;
 	int len, first, i, j, k, b0, d0, b1, d1;
 


### PR DESCRIPTION
When used with the RIOT OS project there is a naming clash
for the align define. Ideally each project would prefix their
symbols.

Tested that it builds with all tests.