### PR TITLE
Fix GCC warning regarding strcpy.

### DIFF
--- a/include/relic_arch.h
+++ b/include/relic_arch.h
@@ -67,7 +67,7 @@
 #if ARCH == AVR
 #define FETCH(STR, ID, L)	arch_copy_rom(STR, STRING(ID), L);
 #else
-#define FETCH(STR, ID, L)	strncpy(STR, ID, L);
+#define FETCH(STR, ID, L)	memcpy(STR, ID, L);
 #endif
 
 /*============================================================================*/


### PR DESCRIPTION
GCC's -Wsizeof-pointer-memaccess (activated by -Wall) checks calls of the form

  strncpy(dest, src, sizeof(X))

And emits a warning if X does not seem to make sense. In Relic, src = X= a constant
string and this triggers gcc's warning.

I replaced stncpy by memcpy. Because the strings being usd do not contain embedded
zeroes, this should not be a proble,