### PR TITLE
Check if MIN/MAX are not defined before adding Macros

### DIFF
--- a/include/relic_util.h
+++ b/include/relic_util.h
@@ -50,8 +50,9 @@
  * @param[in] B		- the second number.
  * @returns			- the smaller number.
  */
+#ifndef MIN
 #define MIN(A, B)			((A) < (B) ? (A) : (B))
-
+#endif
 /**
  * Returns the maximum between two numbers.
  *
@@ -59,8 +60,9 @@
  * @param[in] B		- the second number.
  * @returns			- the bigger number.
  */
+#ifndef MAX
 #define MAX(A, B)			((A) > (B) ? (A) : (B))
-
+#endif
 /**
  * Splits a bit count in a digit count and an updated bit count.
  *


### PR DESCRIPTION
Avoid redefining MIN/MAX if already defined to avoid warning messages