### PR TITLE
Correctly intialize the norm flag in ep2_set_infty

### DIFF
--- a/src/epx/relic_ep2_util.c
+++ b/src/epx/relic_ep2_util.c
@@ -43,6 +43,7 @@ void ep2_set_infty(ep2_t p) {
 	fp2_zero(p->x);
 	fp2_zero(p->y);
 	fp2_zero(p->z);
+	p->norm = p->norm;
 }
 
 void ep2_copy(ep2_t r, ep2_t p) {


### PR DESCRIPTION
Without this, the flag is uninitialized. "Luckily", the uninitialized value evaluates to "true" in most cases, so this was probably never noticed.