### PR TITLE
Second try to correctly initialize p->norm

### DIFF
--- a/src/epx/relic_ep2_util.c
+++ b/src/epx/relic_ep2_util.c
@@ -43,7 +43,7 @@ void ep2_set_infty(ep2_t p) {
 	fp2_zero(p->x);
 	fp2_zero(p->y);
 	fp2_zero(p->z);
-	p->norm = p->norm;
+	p->norm = 1;
 }
 
 void ep2_copy(ep2_t r, ep2_t p) {


### PR DESCRIPTION
While syncing relic and https://github.com/Chia-Network/bls-signatures I noticed that I made a quite stupid mistake "backporting" this change to relic...this is my second try :see_no_evil: 