### PR TITLE
Only subtract 1 in bn_div_imp if remainder is not 0 and different sig…

### DIFF
--- a/src/bn/relic_bn_div.c
+++ b/src/bn/relic_bn_div.c
@@ -94,7 +94,7 @@ static void bn_div_imp(bn_t c, bn_t d, const bn_t a, const bn_t b) {
 			q->used = a->used - b->used + 1;
 			q->sign = sign;
 			bn_trim(q);
-			if (bn_sign(a) == bn_sign(b)) {
+			if ((bn_sign(a) == bn_sign(b) || bn_is_zero(r))) {
 				bn_copy(c, q);
 			} else {
 				bn_sub_dig(c, q, 1);


### PR DESCRIPTION
…ned inputs
This fixes the following problem, i.e. dividing -1 by 1 gives -2 instead of -1
        int64_t one = 1;
        bn_set_dig(a, one);
        bn_set_dig(b, one);
        bn_neg(a, a); // Negate
        printf("a = ");
        bn_print(a);
        printf("b = ");
        bn_print(b);
        bn_div(c, a, b);
        printf("a/b = ");
        bn_print(c);

gives
a = -1
b = 1
a/b = -2