### PR TITLE
Add check for zero for remainder to fix issue with bn_mod_basic(c,a,b)

### DIFF
--- a/src/bn/relic_bn_div.c
+++ b/src/bn/relic_bn_div.c
@@ -94,7 +94,7 @@ static void bn_div_imp(bn_t c, bn_t d, const bn_t a, const bn_t b) {
 			q->used = a->used - b->used + 1;
 			q->sign = sign;
 			bn_trim(q);
-			if ((bn_sign(a) == bn_sign(b) || bn_is_zero(r))) {
+			if ((bn_is_zero(r)) || (bn_sign(a) == bn_sign(b))) {
 				bn_copy(c, q);
 			} else {
 				bn_sub_dig(c, q, 1);
@@ -105,7 +105,7 @@ static void bn_div_imp(bn_t c, bn_t d, const bn_t a, const bn_t b) {
 			r->used = b->used;
 			r->sign = b->sign;
 			bn_trim(r);
-			if (bn_sign(a) == bn_sign(b)) {
+			if ((bn_is_zero(r)) || (bn_sign(a) == bn_sign(b))) {
 				bn_copy(d, r);
 			} else {
 				bn_sub(d, b, r);


### PR DESCRIPTION
where a = -4, b = 2 gives c = 2 instead of c= 0
Simpler test case
bn_mod_basic(c,a,b) a=-1, b= 1, gives c=1 instead of c=0

       int64_t one = 1;
        bn_set_dig(a, one);
        bn_set_dig(b, one);
        bn_neg(a, a);
        printf("a = ");
        bn_print(a);
        printf("b = ");
        bn_print(b);
        bn_mod_basic(c, a, b);
        printf("a mod b = ");
        bn_print(c);