### PR TITLE
fix build on macos when compiling with curve2251-sse

### DIFF
--- a/src/low/curve2251-sse/CMakeLists.txt
+++ b/src/low/curve2251-sse/CMakeLists.txt
@@ -1,2 +1,5 @@
 include(${CMAKE_SOURCE_DIR}/cmake/gmp.cmake)
-set(ARITH_LIBS "gmp")
+if(GMP_FOUND)
+  include_directories(${GMP_INCLUDE_DIR})
+  set(ARITH_LIBS ${GMP_LIBRARIES})
+endif(GMP_FOUND)


### PR DESCRIPTION
Hello,

This PR fixes a build issue I was having on macos when compiling with curve2251-sse. Specifically with the follow cmake command:

```
cmake -DALIGN=16 -DARCH=X64 -DARITH=curve2251-sse -DCHECK=off -DFB_POLYN=251 -DFB_METHD="INTEG;INTEG;QUICK;QUICK;QUICK;QUICK;LOWER;SLIDE;QUICK" -DFB_PRECO=on -DFB_SQRTF=off -DEB_METHD="PROJC;LODAH;COMBD;INTER" -DEC_METHD="CHAR2" -DCOMP="-O3 -funroll-loops -fomit-frame-pointer -march=native -msse4.2 -mpclmul" -DTIMER=CYCLE -DWITH="MD;DV;BN;FB;EB;EC" -DWSIZE=64 .
```

Thanks!
