### PR TITLE
Change CMAKE_SOURCE_DIR to RELIC_SOURCE_DIR

### DIFF
--- a/src/low/curve2251-sse/CMakeLists.txt
+++ b/src/low/curve2251-sse/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(${CMAKE_SOURCE_DIR}/cmake/gmp.cmake)
+include(${RELIC_SOURCE_DIR}/cmake/gmp.cmake)
 if(GMP_FOUND)
   include_directories(${GMP_INCLUDE_DIR})
   set(ARITH_LIBS ${GMP_LIBRARIES})


### PR DESCRIPTION
In curve2251-sse the CMAKE_SOURCE_DIR is changed to RELIC_SOURCE_DIR to make it possible to include the project as subproject.

#114 is fixed by this.