### PR TITLE
Fixing primality testing

### DIFF
--- a/src/bn/relic_bn_prime.c
+++ b/src/bn/relic_bn_prime.c
@@ -217,7 +217,7 @@ int bn_is_prime_basic(const bn_t a) {
 
 int bn_is_prime_rabin(const bn_t a) {
 	bn_t t, n1, y, r;
-	int i, s, j, result, b, tests = 0;
+	int i, s, j, result, b, tests = 0, cmp2;
 
 	tests = 0;
 	result = 1;
@@ -227,8 +227,14 @@ int bn_is_prime_rabin(const bn_t a) {
 	bn_null(y);
 	bn_null(r);
 
-	if (bn_cmp_dig(a, 1) == RLC_EQ) {
+	cmp2 = bn_cmp_dig(a, 2);
+	if (cmp2 == RLC_LT) {
+		/* Numbers 1 or smaller are not prime */
 		return 0;
+	}
+	if (cmp2 == RLC_EQ) {
+		/* The number 2 is prime */
+		return 1;
 	}
 
 	TRY {

--- a/test/test_bn.c
+++ b/test/test_bn.c
@@ -1658,6 +1658,67 @@ static int prime(void) {
 	return code;
 }
 
+static int small_primes(void) {
+	int code = RLC_ERR;
+
+	int i;
+	const int nr_tests = 50;
+
+	dig_t primes[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43,
+			47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103,
+			107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163,
+			167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227,
+			229};
+
+	dig_t non_primes[] = {1, 4, 6, 8, 9, 10, 12, 14, 15, 16, 18, 20, 21, 22,
+			24, 25, 26, 27, 28, 30, 32, 33, 34, 35, 36, 38, 39, 40,
+			42, 44, 45, 46, 48, 49, 50, 51, 52, 54, 55, 56, 57, 58,
+			60, 62, 63, 64, 65, 66, 68, 69};
+
+	bn_t p;
+	bn_null(p);
+
+	TRY {
+		bn_new(p);
+
+		TEST_ONCE("prime testing of small primes is correct") {
+			for(i = 0; i < nr_tests; i++) {
+				bn_set_dig(p, primes[i]);
+				TEST_ASSERT(bn_is_prime(p) == 1, end);
+			}
+		} TEST_END;
+
+		TEST_ONCE("miller-rabin testing of small primes is correct") {
+			for(i = 0; i < nr_tests; i++) {
+				bn_set_dig(p, primes[i]);
+				TEST_ASSERT(bn_is_prime_rabin(p) == 1, end);
+			}
+		} TEST_END;
+
+		TEST_ONCE("prime testing of small non-primes is correct") {
+			for(i = 0; i < nr_tests; i++) {
+				bn_set_dig(p, non_primes[i]);
+				TEST_ASSERT(bn_is_prime(p) == 0, end);
+			}
+		} TEST_END;
+
+		TEST_ONCE("miller-rabin testing of small non-primes is correct") {
+			for(i = 0; i < nr_tests; i++) {
+				bn_set_dig(p, non_primes[i]);
+				TEST_ASSERT(bn_is_prime_rabin(p) == 0, end);
+			}
+		} TEST_END;
+	}
+	CATCH_ANY {
+		ERROR(end);
+	}
+	code = RLC_OK;
+  end:
+	bn_free(p);
+	return code;
+}
+
+
 static int factor(void) {
 	int code = RLC_ERR;
 	bn_t p, q, n;
@@ -2095,6 +2156,11 @@ int main(void) {
 	}
 
 	if (prime() != RLC_OK) {
+		core_clean();
+		return 1;
+	}
+
+	if (small_primes() != RLC_OK) {
 		core_clean();
 		return 1;
 	}


### PR DESCRIPTION
While creating a small Python wrapper I encountered some funky problems with the primality tests.

I added a test-suite to explicitly test a small number of prime and non-primes (they failed ;)). And corrected the Miller-Rabin implementation to be consistent with Algorithm 4.24 in the Handbook of Applied Cryptography.