### PR TITLE
Fix G1/G2 aliases for table size

### DIFF
--- a/include/relic_pc.h
+++ b/include/relic_pc.h
@@ -78,12 +78,12 @@
 /**
  * Represents a G_1 precomputable table.
  */
-#define RLC_G1_TABLE			RLC_CAT(RLC_CAT(RLC_, G1_UPPER), _TABLE_MAX)
+#define RLC_G1_TABLE			RLC_CAT(RLC_CAT(RLC_, G1_UPPER), _TABLE)
 
 /**
  * Represents a G_2 precomputable table.
  */
-#define RLC_G2_TABLE			RLC_CAT(RLC_CAT(RLC_, G2_UPPER), _TABLE_MAX)
+#define RLC_G2_TABLE			RLC_CAT(RLC_CAT(RLC_, G2_UPPER), _TABLE)
 
 /*============================================================================*/
 /* Type definitions                                                           */


### PR DESCRIPTION
It seems intended behavior for RLC_G1/G2_TABLE to point to RLC_EP/EP2_TABLE
instead of _TABLE_MAX