### PR TITLE
fp sign should always be respected

### DIFF
--- a/src/fp/relic_fp_util.c
+++ b/src/fp/relic_fp_util.c
@@ -192,11 +192,11 @@ void fp_read_str(fp_t a, const char *str, int len, int radix) {
 		} else {
 			if (t->used == 1) {
 				fp_prime_conv_dig(a, t->dp[0]);
-				if (bn_sign(t) == RLC_NEG) {
-					fp_neg(a, a);
-				}
 			} else {
 				fp_prime_conv(a, t);
+			}
+			if (bn_sign(t) == RLC_NEG) {
+				fp_neg(a, a);
 			}
 		}
 	}


### PR DESCRIPTION
The existing version only sets the sign for numbers that fit into
one digit. I think it should set the sign for all numbers, right?