### PR TITLE
simplified hash-to-field, other small fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,8 @@ message("   BIGED=[off|on] Build with big-endian support.")
 message("   SHLIB=[off|on] Build shared library.")
 message("   STLIB=[off|on] Build static library.")
 message("   STBIN=[off|on] Build static binaries.")
-message("   AMALG=[off|on] Build amalgamation for better performance.\n")
+message("   AMALG=[off|on] Build amalgamation for better performance.")
+message("   AUSAN=[off|on] Build with ASan and UBSan (gcc/clang only).\n")
 
 option(DEBUG "Build with debugging support" off)
 option(PROFL "Build with profiling support" off)
@@ -51,6 +52,7 @@ option(SHLIB "Build shared library" on)
 option(STLIB "Build static library" on)
 option(STBIN "Build static binaries" off)
 option(AMALG "Build amalgamation" off)
+option(AUSAN "Build with ASan and UBSan (gcc/clang only)" off)
 
 message(STATUS "Number of times each test or benchmark is ran (default = 50, 1000):\n")
 
@@ -232,6 +234,10 @@ else()
 	# If the user did not specify compile flags, we use sane defaults.
 	set(CFLAGS "${COMP}")
 	set(DFLAGS "")
+endif()
+
+if(AUSAN)
+	set(DFLAGS "${DFLAGS} -ggdb -fsanitize=address -fsanitize=undefined")
 endif()
 
 if(MULTI STREQUAL OPENMP)

--- a/include/relic_core.h
+++ b/include/relic_core.h
@@ -269,14 +269,8 @@ typedef struct _ctx_t {
 	bn_st ep_h;
 	/** The distinguished non-square used by the mapping function */
 	fp_st ep_map_u;
-	/** The first constant needed for hashing. */
-	fp_st ep_map_c1;
-	/** The second constant needed for hashing. */
-	fp_st ep_map_c2;
-	/** The third constant needed for hashing. */
-	fp_st ep_map_c3;
-	/** The fourth constant needed for hashing. */
-	fp_st ep_map_c4;
+	/** Precomputed constants for hashing. */
+	fp_st ep_map_c[4];
 	/** The number of excess bits to use when choosing a random field element. */
 	int ep_extra_bits;
 #ifdef EP_ENDOM

--- a/src/ep/relic_ep_curve.c
+++ b/src/ep/relic_ep_curve.c
@@ -86,10 +86,10 @@ static void ep_curve_set_map_consts(void) {
 	const int abNeq0 = (ep_curve_opt_a() != RLC_ZERO) && (ep_curve_opt_b() != RLC_ZERO);
 
 	ctx_t *ctx = core_get();
-	dig_t *c1 = ctx->ep_map_c1;
-	dig_t *c2 = ctx->ep_map_c2;
-	dig_t *c3 = ctx->ep_map_c3;
-	dig_t *c4 = ctx->ep_map_c4;
+	dig_t *c1 = ctx->ep_map_c[0];
+	dig_t *c2 = ctx->ep_map_c[1];
+	dig_t *c3 = ctx->ep_map_c[2];
+	dig_t *c4 = ctx->ep_map_c[3];
 
 	if (ep_curve_is_isomap() || abNeq0) {
 		/* SSWU map constants */

--- a/src/ep/relic_ep_curve.c
+++ b/src/ep/relic_ep_curve.c
@@ -120,9 +120,9 @@ static void ep_curve_set_map_consts(void) {
 		fp_add(c1, c1, ctx->ep_b);
 
 		/* start computing constant 2: -u / 2 */
-		fp_set_dig(c2, 1);
-		fp_neg(c2, c2);                /* -1 is always even... */
-		fp_rsh(c2, c2, 1);             /* ...so this is -1/2 */
+		fp_set_dig(c2, 2);
+		fp_neg(c2, c2);                /* -2 */
+		fp_inv(c2, c2);                /* -1/2 */
 		fp_mul(c2, c2, ctx->ep_map_u); /* c2 = -1/2 * u */
 
 		/* constant 3: sqrt(-g(u) * (3 * u^2 + 4 * a)) */

--- a/src/ep/relic_ep_map.c
+++ b/src/ep/relic_ep_map.c
@@ -319,7 +319,7 @@ void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst
 		 *          Consider making the hash function a per-curve option!
 		 */
 		const int len_per_elm = (FP_PRIME + core_get()->ep_extra_bits + 7) / 8;
-		md_xmd(pseudo_random_bytes, 2 * len_per_elm, msg, len, dst, dst_len);
+		md_xof(pseudo_random_bytes, 2 * len_per_elm, msg, len, dst, dst_len);
 
 #define EP_MAP_CONVERT_BYTES(IDX)                                                        \
 	do {                                                                                 \

--- a/src/ep/relic_ep_map.c
+++ b/src/ep/relic_ep_map.c
@@ -125,9 +125,9 @@ static void ep_map_sswu(ep_t p, const fp_t t) {
 		fp_new(t3);
 
 		ctx_t *ctx = core_get();
-		dig_t *mBoverA = ctx->ep_map_c1;
-		dig_t *a = ctx->ep_map_c3;
-		dig_t *b = ctx->ep_map_c4;
+		dig_t *mBoverA = ctx->ep_map_c[0];
+		dig_t *a = ctx->ep_map_c[2];
+		dig_t *b = ctx->ep_map_c[3];
 		dig_t *u = ctx->ep_map_u;
 
 		/* start computing the map */
@@ -209,10 +209,10 @@ static void ep_map_svdw(ep_t p, const fp_t t) {
 		fp_new(t4);
 
 		ctx_t *ctx = core_get();
-		dig_t *gU = ctx->ep_map_c1;
-		dig_t *mUover2 = ctx->ep_map_c2;
-		dig_t *c3 = ctx->ep_map_c3;
-		dig_t *c4 = ctx->ep_map_c4;
+		dig_t *gU = ctx->ep_map_c[0];
+		dig_t *mUover2 = ctx->ep_map_c[1];
+		dig_t *c3 = ctx->ep_map_c[2];
+		dig_t *c4 = ctx->ep_map_c[3];
 		dig_t *u = ctx->ep_map_u;
 
 		/* start computing the map */

--- a/src/md/relic_md_xof.c
+++ b/src/md/relic_md_xof.c
@@ -62,7 +62,7 @@
  */
 #define _make_md_xof(HName, HBlockSize, HHashSize, HContext, HReset, HInput, HResult)                             \
 	void HName(uint8_t *buf, int buf_len, const uint8_t *in, int in_len, const uint8_t *dst, int dst_len) {       \
-		const int ell = (buf_len + HHashSize - 1) / HHashSize;                                                    \
+		const unsigned ell = (buf_len + HHashSize - 1) / HHashSize;                                               \
 		if (ell > 255 || buf_len < 0) {                                                                           \
 			THROW(ERR_NO_VALID);                                                                                  \
 		}                                                                                                         \

--- a/test/test_fp.c
+++ b/test/test_fp.c
@@ -145,9 +145,7 @@ static int util(void) {
 				fp_write_str(str, bits, a, j);
 				fp_read_str(b, str, strlen(str), j);
 				/* Test also negative integers. */
-				for (int k = strlen(str); k >= 0; k--) {
-					str[k + 1] = str[k];
-				}
+				memmove(str + 1, str, strlen(str) + 1);
 				str[0] = '-';
 				fp_read_str(b, str, strlen(str), j);
 				fp_neg(a, a);


### PR DESCRIPTION
This PR simplifies the hash-to-field code to take advantage of the improved fp_prime_conv function.

Also:

- fix one more instance of md_xmd -> md_xof rename that slipped through
- tiny tweak in test_fp (replace a for loop with a `memmove`)
- fix signed-unsigned comparison in md_xof
- adds a new build flag `AUSAN` that enables ASan and UBSan.

ASan appears to turn up some (real) stack buffer overflows. At a glance, they look like one-byte writes past the end of buffers (so: almost certainly not a security issue, and possibly not even a correctness issue, but definitely worth fixing).

UBSan mostly reports errors caused by left shifts by 64 bits for 64-bit types. These are indeed undefined behavior, but I'm not sure how to avoid them when building a 64-bit mask using a macro like

    #define MASK(SZ) (((uint64_t)1 << (SZ)) - 1)

for `SZ == 64`. Something like this would work:

    #define MASK(SZ) ((uint64_t)((SZ) >= 64 ? -1 : ((uint64_t)1 << (SZ)) - 1))

but runs into the classic issue that it evaluates its argument twice. I'm not sure how to avoid double evaluation without resorting to a GNU extension,

    #define MASK(SZ) ({ typeof(SZ) sz__ = (SZ); \
        ((uint64_t)((sz__) >= 64 ? -1 : ((uint64_t)1 << (sz__)) - 1)); })