### PR TITLE
update notion of 'sign' for mapping ; correctness for affine coords

### DIFF
--- a/src/ep/relic_ep_map.c
+++ b/src/ep/relic_ep_map.c
@@ -125,10 +125,15 @@ void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int ds
 		/* first map invocation */
 		EP_MAP_CONVERT_BYTES(0);
 		EP_MAP_APPLY_MAP(p);
+		TMPL_MAP_CALL_ISOMAP(,p);
 
 		/* second map invocation */
 		EP_MAP_CONVERT_BYTES(1);
 		EP_MAP_APPLY_MAP(q);
+		TMPL_MAP_CALL_ISOMAP(,q);
+
+		/* XXX(rsw) could add p and q and then apply isomap,
+		 * but need ep_add to support addition on isogeny curves */
 
 #undef EP_MAP_CONVERT_BYTES
 #undef EP_MAP_APPLY_MAP

--- a/src/ep/relic_ep_map.c
+++ b/src/ep/relic_ep_map.c
@@ -70,8 +70,14 @@ TMPL_MAP_SSWU(,dig_t,EP_MAP_COPY_COND)
 TMPL_MAP_SVDW(,dig_t,EP_MAP_COPY_COND)
 #undef EP_MAP_COPY_COND
 
+/* caution: this function overwrites k, which it uses as an auxiliary variable */
+static inline int fp_sgn0(const fp_t t, bn_t k) {
+	fp_prime_back(k, t);
+	return bn_get_bit(k, 0);
+}
+
 void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
-	bn_t k, pm1o2;
+	bn_t k;
 	fp_t t;
 	ep_t q;
 	int neg;
@@ -80,30 +86,17 @@ void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int ds
 	uint8_t *pseudo_random_bytes = RLC_ALLOCA(uint8_t, 4 * len_per_elm);
 
 	bn_null(k);
-	bn_null(pm1o2);
 	fp_null(t);
 	ep_null(q);
 
 	TRY {
 		bn_new(k);
-		bn_new(pm1o2);
 		fp_new(t);
 		ep_new(q);
 
 		/* figure out which hash function to use */
 		const int abNeq0 = (ep_curve_opt_a() != RLC_ZERO) && (ep_curve_opt_b() != RLC_ZERO);
 		void (*const map_fn)(ep_t, fp_t) = (ep_curve_is_ctmap() || abNeq0) ? ep_map_sswu : ep_map_svdw;
-
-		/* XXX(rsw) Using (p-1)/2 for sign of y is the sgn0_be variant from
-		 *          draft-irtf-cfrg-hash-to-curve-06. Not all curves want to
-		 *          use this variant! This should be fixed per-curve, probably
-		 *          using a separate sgn0 function.
-		 */
-		/* need (p-1)/2 for fixing sign of y */
-		pm1o2->sign = RLC_POS;
-		pm1o2->used = RLC_FP_DIGS;
-		dv_copy(pm1o2->dp, fp_prime_get(), RLC_FP_DIGS);
-		bn_hlv(pm1o2, pm1o2);
 
 		/* for hash_to_field, need to hash to a pseudorandom string */
 		/* XXX(rsw) the below assumes that we want to use MD_MAP for hashing.
@@ -120,14 +113,13 @@ void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int ds
 #define EP_MAP_APPLY_MAP(PT)                                                   \
 	do {                                                                       \
 		/* check sign of t */                                                  \
-		fp_prime_back(k, t);                                                   \
-		neg = bn_cmp(k, pm1o2);                                                \
+		neg = fp_sgn0(t, k);                                                   \
 		/* convert */                                                          \
 		map_fn(PT, t);                                                         \
-		/* fix sign of y */                                                    \
-		fp_prime_back(k, PT->y);                                               \
+		/* compare sign of y and sign of t; fix if necessary */                \
+		neg = neg != fp_sgn0(PT->y, k);                                        \
 		fp_neg(t, PT->y);                                                      \
-		dv_copy_cond(PT->y, t, RLC_FP_DIGS, neg != bn_cmp(k, pm1o2));          \
+		dv_copy_cond(PT->y, t, RLC_FP_DIGS, neg);                              \
 	} while (0)
 
 		/* first map invocation */
@@ -180,7 +172,6 @@ void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int ds
 	}
 	FINALLY {
 		bn_free(k);
-		bn_free(pm1o2);
 		fp_free(t);
 		ep_free(q);
 		RLC_FREE(pseudo_random_bytes);

--- a/src/epx/relic_ep2_map.c
+++ b/src/epx/relic_ep2_map.c
@@ -243,10 +243,15 @@ void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int 
 		/* first map invocation */
 		EP2_MAP_CONVERT_BYTES(0);
 		EP2_MAP_APPLY_MAP(p);
+		TMPL_MAP_CALL_ISOMAP(2,p);
 
 		/* second map invocation */
 		EP2_MAP_CONVERT_BYTES(1);
 		EP2_MAP_APPLY_MAP(q);
+		TMPL_MAP_CALL_ISOMAP(2,q);
+
+		/* XXX(rsw) could add p and q and then apply isomap,
+		 * but need ep_add to support addition on isogeny curves */
 
 #undef EP2_MAP_CONVERT_BYTES
 #undef EP2_MAP_APPLY_MAP

--- a/src/epx/relic_ep2_map.c
+++ b/src/epx/relic_ep2_map.c
@@ -179,21 +179,22 @@ static void ep2_mul_cof_b12(ep2_t r, ep2_t p) {
 	}
 }
 
-static inline int fp2_sgn0(const fp2_t t, bn_t k, const bn_t pm1o2) {
+/* caution: this function overwrites k, which it uses as an auxiliary variable */
+static inline int fp2_sgn0(const fp2_t t, bn_t k) {
 	const int t_0_zero = fp_is_zero(t[0]);
 
 	fp_prime_back(k, t[0]);
-	const int t_0_neg = bn_cmp(k, pm1o2);
+	const int t_0_neg = bn_get_bit(k, 0);
 
 	fp_prime_back(k, t[1]);
-	const int t_1_neg = bn_cmp(k, pm1o2);
+	const int t_1_neg = bn_get_bit(k, 0);
 
 	/* t[0] == 0 ? sgn0(t[1]) : sgn0(t[0]) */
-	return (!t_0_zero) * t_0_neg + t_0_zero * t_1_neg;
+	return t_0_neg | (t_0_zero & t_1_neg);
 }
 
 void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
-	bn_t k, pm1o2;
+	bn_t k;
 	fp2_t t;
 	ep2_t q;
 	int neg;
@@ -202,26 +203,17 @@ void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int 
 	uint8_t *pseudo_random_bytes = RLC_ALLOCA(uint8_t, 4 * len_per_elm);
 
 	bn_null(k);
-	bn_null(pm1o2);
 	fp2_null(t);
 	ep2_null(q);
 
 	TRY {
 		bn_new(k);
-		bn_new(pm1o2);
 		fp2_new(t);
 		ep2_new(q);
 
 		/* which hash function should we use? */
 		const int abNeq0 = (ep2_curve_opt_a() != RLC_ZERO) && (ep2_curve_opt_b() != RLC_ZERO);
 		void (*const map_fn)(ep2_t, fp2_t) = (ep2_curve_is_ctmap() || abNeq0) ? ep2_map_sswu : ep2_map_svdw;
-
-		/* XXX(rsw) See note in ep/relic_ep_map.c about sgn0 variants. */
-		/* (p-1)/2 for detecting sign of y */
-		pm1o2->sign = RLC_POS;
-		pm1o2->used = RLC_FP_DIGS;
-		dv_copy(pm1o2->dp, fp_prime_get(), RLC_FP_DIGS);
-		bn_hlv(pm1o2, pm1o2);
 
 		/* XXX(rsw) See note in ep/relic_ep_map.c about using MD_MAP. */
 		/* hash to a pseudorandom string using md_xmd */
@@ -238,11 +230,11 @@ void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int 
 #define EP2_MAP_APPLY_MAP(PT)                                                            \
 	do {                                                                                 \
 		/* sign of t */                                                                  \
-		neg = fp2_sgn0(t, k, pm1o2);                                                     \
+		neg = fp2_sgn0(t, k);                                                            \
 		/* convert */                                                                    \
 		map_fn(PT, t);                                                                   \
 		/* compare sign of y to sign of t; fix if necessary */                           \
-		neg = neg != fp2_sgn0(PT->y, k, pm1o2);                                          \
+		neg = neg != fp2_sgn0(PT->y, k);                                                 \
 		fp2_neg(t, PT->y);                                                               \
 		dv_copy_cond(PT->y[0], t[0], RLC_FP_DIGS, neg);                                  \
 		dv_copy_cond(PT->y[1], t[1], RLC_FP_DIGS, neg);                                  \
@@ -287,7 +279,6 @@ void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int 
 	}
 	FINALLY {
 		bn_free(k);
-		bn_free(pm1o2);
 		fp2_free(t);
 		ep2_free(q);
 		RLC_FREE(pseudo_random_bytes);

--- a/src/tmpl/relic_tmpl_map.h
+++ b/src/tmpl/relic_tmpl_map.h
@@ -46,6 +46,13 @@
 		}                                                                                \
 	}
 
+/* conditionally normalize result of isogeny map when not using projective coords */
+#if EP_ADD != PROJC
+#define TMPL_MAP_ISOMAP_NORM(EXTDEG) ep##EXTDEG##_norm(q, q)
+#else
+#define TMPL_MAP_ISOMAP_NORM(EXTDEG) (void)q
+#endif
+
 /**
  * Generic isogeny map evaluation for use with SSWU map.
  */
@@ -94,6 +101,9 @@
 			fp##EXTDEG##_mul(q->x, t0, t2);                                              \
 			fp##EXTDEG##_mul(q->x, q->x, q->z);                                          \
 			q->norm = 0;                                                                 \
+                                                                                         \
+			/* normalize if necessary */                                                 \
+			TMPL_MAP_ISOMAP_NORM(EXTDEG);                                                \
 		}                                                                                \
 		CATCH_ANY { THROW(ERR_CAUGHT); }                                                 \
 		FINALLY {                                                                        \
@@ -265,7 +275,8 @@
 			fp##EXTDEG##_set_dig(p->z, 1);                                                         \
 			p->norm = 1;                                                                           \
 		}                                                                                          \
-		CATCH_ANY{THROW(ERR_CAUGHT)} FINALLY {                                                     \
+		CATCH_ANY { THROW(ERR_CAUGHT); }                                                           \
+		FINALLY {                                                                                  \
 			fp##EXTDEG##_free(t1);                                                                 \
 			fp##EXTDEG##_free(t2);                                                                 \
 			fp##EXTDEG##_free(t3);                                                                 \

--- a/src/tmpl/relic_tmpl_map.h
+++ b/src/tmpl/relic_tmpl_map.h
@@ -116,14 +116,14 @@
 
 /* Conditionally call isogeny mapping function depending on whether EP_CTMAP is defined */
 #ifdef EP_CTMAP
-#define TMPL_MAP_CALL_ISOMAP(EXTDEG)                                                     \
+#define TMPL_MAP_CALL_ISOMAP(EXTDEG,PT)                                                     \
 	do {                                                                                 \
 		if (ep##EXTDEG##_curve_is_ctmap()) {                                             \
-			ep##EXTDEG##_iso(p, p);                                                      \
+			ep##EXTDEG##_iso(PT, PT);                                                      \
 		}                                                                                \
 	} while (0)
 #else
-#define TMPL_MAP_CALL_ISOMAP(EXTDEG)  /* No isogeny map call in this case. */
+#define TMPL_MAP_CALL_ISOMAP(EXTDEG,PT)  /* No isogeny map call in this case. */
 #endif
 
 /**
@@ -192,8 +192,6 @@
 			}                                                                                      \
 			fp##EXTDEG##_set_dig(p->z, 1);                                                         \
 			p->norm = 1;                                                                           \
-                                                                                                   \
-			TMPL_MAP_CALL_ISOMAP(EXTDEG);                                                          \
 		}                                                                                          \
 		CATCH_ANY { THROW(ERR_CAUGHT); }                                                           \
 		FINALLY {                                                                                  \

--- a/src/tmpl/relic_tmpl_map.h
+++ b/src/tmpl/relic_tmpl_map.h
@@ -47,10 +47,38 @@
 	}
 
 /* conditionally normalize result of isogeny map when not using projective coords */
-#if EP_ADD != PROJC
-#define TMPL_MAP_ISOMAP_NORM(EXTDEG) ep##EXTDEG##_norm(q, q)
+#if EP_ADD == PROJC
+#define TMPL_MAP_ISOMAP_NORM(EXTDEG)                                                     \
+	do {                                                                                 \
+		/* Y = Ny * Dx * Z^2. */                                                         \
+		fp##EXTDEG##_mul(q->y, p->y, t1);                                                \
+		fp##EXTDEG##_mul(q->y, q->y, t3);                                                \
+		/* Z = Dx * Dy, t1 = Z^2. */                                                     \
+		fp##EXTDEG##_mul(q->z, t2, t3);                                                  \
+		fp##EXTDEG##_sqr(t1, q->z);                                                      \
+		fp##EXTDEG##_mul(q->y, q->y, t1);                                                \
+		/* X = Nx * Dy * Z. */                                                           \
+		fp##EXTDEG##_mul(q->x, t0, t2);                                                  \
+		fp##EXTDEG##_mul(q->x, q->x, q->z);                                              \
+		q->norm = 0;                                                                     \
+	} while (0)
 #else
-#define TMPL_MAP_ISOMAP_NORM(EXTDEG) (void)q
+#define TMPL_MAP_ISOMAP_NORM(EXTDEG)                                                     \
+	do {                                                                                 \
+		/* when working with affine coordinates, clear denominator */                    \
+		fp##EXTDEG##_mul(q->z, t2, t3);                                                  \
+		fp##EXTDEG##_inv(q->z, q->z);                                                    \
+		/* y coord */                                                                    \
+		fp##EXTDEG##_mul(q->y, p->y, q->z);                                              \
+		fp##EXTDEG##_mul(q->y, q->y, t3);                                                \
+		fp##EXTDEG##_mul(q->y, q->y, t1);                                                \
+		/* x coord */                                                                    \
+		fp##EXTDEG##_mul(q->x, t2, q->z);                                                \
+		fp##EXTDEG##_mul(q->x, q->x, t0);                                                \
+		/* z coord == 1 */                                                               \
+		fp##EXTDEG##_set_dig(q->z, 1);                                                   \
+		q->norm = 1;                                                                     \
+	} while (0)
 #endif
 
 /**
@@ -89,18 +117,6 @@
 			/* denominators */                                                           \
 			fp##EXTDEG##_eval(t2, p->x, coeffs->yd, coeffs->deg_yd);                     \
 			fp##EXTDEG##_eval(t3, p->x, coeffs->xd, coeffs->deg_xd);                     \
-                                                                                         \
-			/* Y = Ny * Dx * Z^2. */                                                     \
-			fp##EXTDEG##_mul(q->y, p->y, t1);                                            \
-			fp##EXTDEG##_mul(q->y, q->y, t3);                                            \
-			/* Z = Dx * Dy, t1 = Z^2. */                                                 \
-			fp##EXTDEG##_mul(q->z, t2, t3);                                              \
-			fp##EXTDEG##_sqr(t1, q->z);                                                  \
-			fp##EXTDEG##_mul(q->y, q->y, t1);                                            \
-			/* X = Nx * Dy * Z. */                                                       \
-			fp##EXTDEG##_mul(q->x, t0, t2);                                              \
-			fp##EXTDEG##_mul(q->x, q->x, q->z);                                          \
-			q->norm = 0;                                                                 \
                                                                                          \
 			/* normalize if necessary */                                                 \
 			TMPL_MAP_ISOMAP_NORM(EXTDEG);                                                \


### PR DESCRIPTION
This PR does two things:

1. Updates the notion of 'sign' to match the latest hash-to-curve draft.

2. Normalizes the output of the isogeny map when `EP_ADD != PROJC`.