### PR TITLE
Add check in bn_cmp to handle the case of negative 0.

### DIFF
--- a/src/bn/relic_bn_cmp.c
+++ b/src/bn/relic_bn_cmp.c
@@ -73,6 +73,10 @@ int bn_cmp_dig(const bn_t a, dig_t b) {
 }
 
 int bn_cmp(const bn_t a, const bn_t b) {
+	if (bn_is_zero(a) && bn_is_zero(b)) {
+		return RLC_EQ;
+	}
+
 	if (a->sign == RLC_POS && b->sign == RLC_NEG) {
 		return RLC_GT;
 	}


### PR DESCRIPTION
The comparison function was returning incorrect results in the case it receive in argument +0 and -0. A check is added in bn_cmp to handle this case.

Code to test the problem.
```c
#include <stdlib.h>
#include <stdio.h>

#include "relic.h"

int main(int argc, char *argv[]) {
    bn_t a, b, c, d;
    int res;

    core_init();

    bn_null(a);
    bn_null(b);
    bn_null(c);
    bn_null(d);

    bn_new(a);
    bn_new(b);
    bn_new(c);
    bn_new(d);

    bn_rand(a, RLC_POS, RLC_BN_BITS);
    bn_copy(b, a);
    bn_neg(a, a);

    // c and d are now both 0 but of opposite sign due to the implementation of bn_add.
    bn_add(c, a, b);
    bn_add(d, b, a);

    if (bn_cmp(c, d) == RLC_EQ) {
        // success!
        printf("Success!\n");
        res = 0;
    }
    else {
        printf("Failure!\n");
        res = 1;
    }

    bn_free(a);
    bn_free(b);
    bn_free(c);
    bn_free(d);

    return res;
}
```