### PR TITLE
add mapping functions that take explicit DSTs to ep and epx

### DIFF
--- a/include/relic_ep.h
+++ b/include/relic_ep.h
@@ -1169,6 +1169,18 @@ void ep_norm_sim(ep_t *r, const ep_t *t, int n);
 void ep_map(ep_t p, const uint8_t *msg, int len);
 
 /**
+ * Maps a byte array to a point in a prime elliptic curve using
+ * an explicit domain separation tag.
+ *
+ * @param[out] p			- the result.
+ * @param[in] msg			- the byte array to map.
+ * @param[in] len			- the array length in bytes.
+ * @param[in] dst			- the domain separation tag.
+ * @param[in] dst_len		- the domain separation tag length in bytes.
+ */
+void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len);
+
+/**
  * Maps a byte array to a point in a prime elliptic curve with specified
  * domain separation tag (aka personalization string).
  *

--- a/include/relic_epx.h
+++ b/include/relic_epx.h
@@ -936,6 +936,18 @@ void ep2_norm_sim(ep2_t *r, ep2_t *t, int n);
 void ep2_map(ep2_t p, const uint8_t *msg, int len);
 
 /**
+ * Maps a byte array to a point in an elliptic curve over a quadratic extension
+ * using an explicit domain separation tag.
+ *
+ * @param[out] p			- the result.
+ * @param[in] msg			- the byte array to map.
+ * @param[in] len			- the array length in bytes.
+ * @param[in] dst			- the domain separatoin tag.
+ * @param[in] dst_len		- the domain separation tag length in bytes.
+ */
+void ep2_map_dst(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len);
+
+/**
  * Computes a power of the Gailbraith-Lin-Scott homomorphism of a point
  * represented in affine coordinates on a twisted elliptic curve over a
  * quadratic exension. That is, Psi^i(P) = Twist(P)(Frob^i(unTwist(P)).

--- a/include/relic_label.h
+++ b/include/relic_label.h
@@ -1386,6 +1386,7 @@
 #undef ep2_norm
 #undef ep2_norm_sim
 #undef ep2_map
+#undef ep2_map_dst
 #undef ep2_frb
 #undef ep2_pck
 #undef ep2_upk
@@ -1454,6 +1455,7 @@
 #define ep2_norm 	RLC_PREFIX(ep2_norm)
 #define ep2_norm_sim 	RLC_PREFIX(ep2_norm_sim)
 #define ep2_map 	RLC_PREFIX(ep2_map)
+#define ep2_map_dst 	RLC_PREFIX(ep2_map_dst)
 #define ep2_frb 	RLC_PREFIX(ep2_frb)
 #define ep2_pck 	RLC_PREFIX(ep2_pck)
 #define ep2_upk 	RLC_PREFIX(ep2_upk)

--- a/src/ep/relic_ep_map.c
+++ b/src/ep/relic_ep_map.c
@@ -76,7 +76,11 @@ static inline int fp_sgn0(const fp_t t, bn_t k) {
 	return bn_get_bit(k, 0);
 }
 
-static void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
+/*============================================================================*/
+/* Public definitions                                                         */
+/*============================================================================*/
+
+void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
 	bn_t k;
 	fp_t t;
 	ep_t q;
@@ -183,10 +187,6 @@ static void ep_map_impl(ep_t p, const uint8_t *msg, int len, const uint8_t *dst,
 	}
 }
 
-/*============================================================================*/
-/* Public definitions                                                         */
-/*============================================================================*/
-
 void ep_map(ep_t p, const uint8_t *msg, int len) {
-	ep_map_impl(p, msg, len, (const uint8_t *)"RELIC", 5);
+	ep_map_dst(p, msg, len, (const uint8_t *)"RELIC", 5);
 }

--- a/src/epx/relic_ep2_map.c
+++ b/src/epx/relic_ep2_map.c
@@ -193,7 +193,11 @@ static inline int fp2_sgn0(const fp2_t t, bn_t k) {
 	return t_0_neg | (t_0_zero & t_1_neg);
 }
 
-void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
+/*============================================================================*/
+/* Public definitions                                                         */
+/*============================================================================*/
+
+void ep2_map_dst(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
 	bn_t k;
 	fp2_t t;
 	ep2_t q;
@@ -290,10 +294,6 @@ void ep2_map_impl(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int 
 	}
 }
 
-/*============================================================================*/
-/* Public definitions                                                         */
-/*============================================================================*/
-
 void ep2_map(ep2_t p, const uint8_t *msg, int len) {
-	ep2_map_impl(p, msg, len, (const uint8_t *)"RELIC", 5);
+	ep2_map_dst(p, msg, len, (const uint8_t *)"RELIC", 5);
 }

--- a/test/test_ep.c
+++ b/test/test_ep.c
@@ -1099,14 +1099,17 @@ static int compression(void) {
 static int hashing(void) {
 	int code = RLC_ERR;
 	ep_t a;
+	ep_t b;
 	bn_t n;
 	uint8_t msg[5];
 
 	ep_null(a);
+	ep_null(b);
 	bn_null(n);
 
 	RLC_TRY {
 		ep_new(a);
+		ep_new(b);
 		bn_new(n);
 
 		ep_curve_get_ord(n);
@@ -1115,6 +1118,8 @@ static int hashing(void) {
 			rand_bytes(msg, sizeof(msg));
 			ep_map(a, msg, sizeof(msg));
 			TEST_ASSERT(ep_is_infty(a) == 0, end);
+			ep_map_dst(b, msg, sizeof(msg), (const uint8_t *)"RELIC", 5);
+			TEST_ASSERT(ep_cmp(a, b) == RLC_EQ, end);
 			ep_mul(a, a, n);
 			TEST_ASSERT(ep_is_infty(a) == 1, end);
 		}
@@ -1126,6 +1131,7 @@ static int hashing(void) {
 	code = RLC_OK;
   end:
 	ep_free(a);
+	ep_free(b);
 	bn_free(n);
 	return code;
 }

--- a/test/test_epx.c
+++ b/test/test_epx.c
@@ -1016,20 +1016,26 @@ static int hashing(void) {
 	int code = RLC_ERR;
 	bn_t n;
 	ep2_t p;
+	ep2_t q;
 	uint8_t msg[5];
 
 	bn_null(n);
 	ep2_null(p);
+	ep2_null(q);
 
 	RLC_TRY {
 		bn_new(n);
 		ep2_new(p);
+		ep2_new(q);
 
 		ep2_curve_get_ord(n);
 
 		TEST_BEGIN("point hashing is correct") {
 			rand_bytes(msg, sizeof(msg));
 			ep2_map(p, msg, sizeof(msg));
+			TEST_ASSERT(ep2_is_infty(p) == 0, end);
+			ep2_map_dst(q, msg, sizeof(msg), (const uint8_t *)"RELIC", 5);
+			TEST_ASSERT(ep2_cmp(p, q) == RLC_EQ, end);
 			ep2_mul(p, p, n);
 			TEST_ASSERT(ep2_is_infty(p) == 1, end);
 		}
@@ -1043,6 +1049,7 @@ static int hashing(void) {
   end:
 	bn_free(n);
 	ep2_free(p);
+	ep2_free(q);
 	return code;
 }
 


### PR DESCRIPTION
This PR exposes ep_map_dst and ep2_map_dst, which are hash-to-curve functions that take explicit domain separation tags. Applications that use hash-to-curve are expected to set their own DSTs, so exposing these functions will make it possible for implementors to use RELIC for such applications.

#137 adds this function for Edwards curves.

This PR also adds rudimentary tests to make sure that ep_map and ep_map_dst (resp ep2) agree when the DST is set to "RELIC".