### PR TITLE
core_set_thread_initializer and IETF BLS serialization

### DIFF
--- a/include/relic_core.h
+++ b/include/relic_core.h
@@ -446,4 +446,17 @@ ctx_t *core_get(void);
  */
 void core_set(ctx_t *ctx);
 
+// [!CHIA_EDIT_START]
+#if MULTI != RELIC_NONE
+/**
+ * Set an initializer function which is called when the context
+ * is uninitialized. This function is called for every thread.
+ *
+ * @param[in] init function to call when the current context is not initialized
+ * @param[in] init_ptr a pointer which is passed to the initialized
+ */
+void core_set_thread_initializer(void (*init)(void *init_ptr), void *init_ptr);
+#endif
+// [!CHIA_EDIT_END]
+
 #endif /* !RLC_CORE_H */

--- a/include/relic_core.h
+++ b/include/relic_core.h
@@ -446,7 +446,6 @@ ctx_t *core_get(void);
  */
 void core_set(ctx_t *ctx);
 
-// [!CHIA_EDIT_START]
 #if MULTI != RELIC_NONE
 /**
  * Set an initializer function which is called when the context
@@ -457,6 +456,5 @@ void core_set(ctx_t *ctx);
  */
 void core_set_thread_initializer(void (*init)(void *init_ptr), void *init_ptr);
 #endif
-// [!CHIA_EDIT_END]
 
 #endif /* !RLC_CORE_H */

--- a/src/ep/relic_ep_pck.c
+++ b/src/ep/relic_ep_pck.c
@@ -35,7 +35,6 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-//[!CHIA_EDIT_START]
 void ep_pck(ep_t r, const ep_t p) {
 	bn_t halfQ;
 	bn_null(halfQ);
@@ -110,49 +109,3 @@ int ep_upk(ep_t r, const ep_t p) {
 	}
 	return result;
 }
-/*
-void ep_pck(ep_t r, const ep_t p) {
-	int b = fp_get_bit(p->y, 0);
-	fp_copy(r->x, p->x);
-	fp_zero(r->y);
-	fp_set_bit(r->y, 0, b);
-	fp_set_dig(r->z, 1);
-	r->coord = BASIC;
-}
-
-int ep_upk(ep_t r, const ep_t p) {
-	fp_t t;
-	int result = 0;
-
-	fp_null(t);
-
-	RLC_TRY {
-		fp_new(t);
-
-		ep_rhs(t, p);
-
-		// t0 = sqrt(x1^3 + a * x1 + b).
-		result = fp_srt(t, t);
-
-		if (result) {
-			// Verify if least significant bit of the result matches the
-			// compressed y-coordinate.
-			if (fp_get_bit(t, 0) != fp_get_bit(p->y, 0)) {
-				fp_neg(t, t);
-			}
-			fp_copy(r->x, p->x);
-			fp_copy(r->y, t);
-			fp_set_dig(r->z, 1);
-			r->coord = BASIC;
-		}
-	}
-	RLC_CATCH_ANY {
-		RLC_THROW(ERR_CAUGHT);
-	}
-	RLC_FINALLY {
-		fp_free(t);
-	}
-	return result;
-}
-*/
-//[!CHIA_EDIT_END]

--- a/src/ep/relic_ep_pck.c
+++ b/src/ep/relic_ep_pck.c
@@ -35,6 +35,82 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
+//[!CHIA_EDIT_START]
+void ep_pck(ep_t r, const ep_t p) {
+	bn_t halfQ;
+	bn_null(halfQ);
+	bn_new(halfQ);
+	halfQ->used = RLC_FP_DIGS;
+	dv_copy(halfQ->dp, fp_prime_get(), RLC_FP_DIGS);
+	bn_hlv(halfQ, halfQ);
+
+	bn_t yValue;
+	bn_null(yValue);
+	bn_new(yValue);
+	fp_prime_back(yValue, p->y);
+
+	int b = bn_cmp(yValue, halfQ) == RLC_GT;
+
+	bn_free(yValue);
+	bn_free(halfQ);
+
+	fp_copy(r->x, p->x);
+	fp_zero(r->y);
+	fp_set_bit(r->y, 0, b);
+	fp_set_dig(r->z, 1);
+	r->coord = BASIC;
+}
+
+int ep_upk(ep_t r, const ep_t p) {
+	fp_t t;
+	bn_t halfQ;
+	bn_t yValue;
+	int result = 0;
+
+	fp_null(t);
+	bn_null(halfQ);
+	bn_null(yValue);
+
+	RLC_TRY {
+		fp_new(t);
+
+		ep_rhs(t, p);
+
+		/* t0 = sqrt(x1^3 + a * x1 + b). */
+		result = fp_srt(t, t);
+
+		if (result) {
+			/* Verify whether the y coordinate is the larger one, matches the
+			 * compressed y-coordinate. */
+			bn_new(halfQ);
+			halfQ->used = RLC_FP_DIGS;
+			dv_copy(halfQ->dp, fp_prime_get(), RLC_FP_DIGS);
+			bn_hlv(halfQ, halfQ);
+
+			bn_new(yValue);
+			fp_prime_back(yValue, t);
+			int b = bn_cmp(yValue, halfQ) == RLC_GT;
+
+			if (b != fp_get_bit(p->y, 0)) {
+				fp_neg(t, t);
+			}
+			fp_copy(r->x, p->x);
+			fp_copy(r->y, t);
+			fp_set_dig(r->z, 1);
+			r->coord = BASIC;
+		}
+	}
+	RLC_CATCH_ANY {
+		RLC_THROW(ERR_CAUGHT);
+	}
+	RLC_FINALLY {
+		fp_free(t);
+		bn_free(yValue);
+		bn_free(halfQ);
+	}
+	return result;
+}
+/*
 void ep_pck(ep_t r, const ep_t p) {
 	int b = fp_get_bit(p->y, 0);
 	fp_copy(r->x, p->x);
@@ -55,12 +131,12 @@ int ep_upk(ep_t r, const ep_t p) {
 
 		ep_rhs(t, p);
 
-		/* t0 = sqrt(x1^3 + a * x1 + b). */
+		// t0 = sqrt(x1^3 + a * x1 + b).
 		result = fp_srt(t, t);
 
 		if (result) {
-			/* Verify if least significant bit of the result matches the
-			 * compressed y-coordinate. */
+			// Verify if least significant bit of the result matches the
+			// compressed y-coordinate.
 			if (fp_get_bit(t, 0) != fp_get_bit(p->y, 0)) {
 				fp_neg(t, t);
 			}
@@ -78,3 +154,5 @@ int ep_upk(ep_t r, const ep_t p) {
 	}
 	return result;
 }
+*/
+//[!CHIA_EDIT_END]

--- a/src/relic_core.c
+++ b/src/relic_core.c
@@ -82,9 +82,16 @@ rlc_thread ctx_t first_ctx;
 static ctx_t first_ctx;
 #endif
 
-/**
- * Active library context.
+//[!CHIA_EDIT_START]
+#if MULTI != RELIC_NONE
+/*
+ * Initializer function to call for every thread's context
  */
+void (*core_thread_initializer)(void* init_ptr) = NULL;
+void* core_init_ptr = NULL;
+#endif
+//[!CHIA_EDIT_END]
+
 #if MULTI
 rlc_thread ctx_t *core_ctx = NULL;
 #else
@@ -175,9 +182,25 @@ int core_clean(void) {
 }
 
 ctx_t *core_get(void) {
+//[!CHIA_EDIT_START]
+#if MULTI != RELIC_NONE
+    if (core_ctx == NULL && core_thread_initializer != NULL) {
+        core_thread_initializer(core_init_ptr);
+    }
+#endif
+//[!CHIA_EDIT_END]
 	return core_ctx;
 }
 
 void core_set(ctx_t *ctx) {
 	core_ctx = ctx;
 }
+
+//[!CHIA_EDIT_START]
+#if MULTI != RELIC_NONE
+void core_set_thread_initializer(void(*init)(void *init_ptr), void* init_ptr) {
+    core_thread_initializer = init;
+    core_init_ptr = init_ptr;
+}
+#endif
+//[!CHIA_EDIT_END]

--- a/src/relic_core.c
+++ b/src/relic_core.c
@@ -180,13 +180,11 @@ int core_clean(void) {
 }
 
 ctx_t *core_get(void) {
-//[!CHIA_EDIT_START]
 #if MULTI != RELIC_NONE
     if (core_ctx == NULL && core_thread_initializer != NULL) {
         core_thread_initializer(core_init_ptr);
     }
 #endif
-//[!CHIA_EDIT_END]
 	return core_ctx;
 }
 
@@ -194,11 +192,9 @@ void core_set(ctx_t *ctx) {
 	core_ctx = ctx;
 }
 
-//[!CHIA_EDIT_START]
 #if MULTI != RELIC_NONE
 void core_set_thread_initializer(void(*init)(void *init_ptr), void* init_ptr) {
     core_thread_initializer = init;
     core_init_ptr = init_ptr;
 }
 #endif
-//[!CHIA_EDIT_END]

--- a/src/relic_core.c
+++ b/src/relic_core.c
@@ -82,7 +82,6 @@ rlc_thread ctx_t first_ctx;
 static ctx_t first_ctx;
 #endif
 
-//[!CHIA_EDIT_START]
 #if MULTI != RELIC_NONE
 /*
  * Initializer function to call for every thread's context
@@ -90,7 +89,6 @@ static ctx_t first_ctx;
 void (*core_thread_initializer)(void* init_ptr) = NULL;
 void* core_init_ptr = NULL;
 #endif
-//[!CHIA_EDIT_END]
 
 #if MULTI
 rlc_thread ctx_t *core_ctx = NULL;

--- a/src/relic_util.c
+++ b/src/relic_util.c
@@ -151,9 +151,8 @@ int util_cmp_const(const void *a, const void *b, int size) {
 	return (result == 0 ? RLC_EQ : RLC_NE);
 }
 
-#ifndef RLC_NOUTILPRINT
-void util_print(const char *format, ...) {
 #ifndef QUIET
+void util_print(const char *format, ...) {
 #if ARCH == AVR && !defined(OPSYS)
 	util_print_ptr = print_buf + 1;
 	va_list list;
@@ -184,7 +183,6 @@ void util_print(const char *format, ...) {
 	vprintf(format, list);
 	fflush(stdout);
 	va_end(list);
-#endif
 #endif
 }
 #endif

--- a/src/relic_util.c
+++ b/src/relic_util.c
@@ -150,7 +150,7 @@ int util_cmp_const(const void *a, const void *b, int size) {
 
 	return (result == 0 ? RLC_EQ : RLC_NE);
 }
-
+/*
 void util_print(const char *format, ...) {
 #ifndef QUIET
 #if ARCH == AVR && !defined(OPSYS)
@@ -186,7 +186,7 @@ void util_print(const char *format, ...) {
 #endif
 #endif
 }
-
+*/
 void util_print_dig(dig_t a, int pad) {
 #if RLC_DIG == 64
 	if (pad) {

--- a/src/relic_util.c
+++ b/src/relic_util.c
@@ -150,7 +150,8 @@ int util_cmp_const(const void *a, const void *b, int size) {
 
 	return (result == 0 ? RLC_EQ : RLC_NE);
 }
-/*
+
+#ifndef RLC_NOUTILPRINT
 void util_print(const char *format, ...) {
 #ifndef QUIET
 #if ARCH == AVR && !defined(OPSYS)
@@ -186,7 +187,8 @@ void util_print(const char *format, ...) {
 #endif
 #endif
 }
-*/
+#endif
+
 void util_print_dig(dig_t a, int pad) {
 #if RLC_DIG == 64
 	if (pad) {


### PR DESCRIPTION
This PR adds:

1) core_set_thread_initializer() which allows an application to do custom per thread initialization (needed for BLS) 
2) IETF BLS serialization
3) #ifndef QUIET util_print() to help compilers that do not support variadic functions

Caution: We modified the ep_pck() and ep_upk() routines to conform to the BLS IETF specification. This change does alter the behavior of Relic!!! See below:

Each x coordinate has two potential y coordinates based on the formula y^2 = x^3 + 4, but in the serialization we only store the x, which can be used to compute the y (sqrt(x^3 + 4))

However, sqrt returns two possibilities, y and -y, since everything is module a prime q, -y = (q - y). So we need to add one bit to the serialization to say which y it is. 

In current Relic, the bit is set to 1 if y is odd, and 0 if y is even. If y is odd, -y must be even since it's mod q which is odd

In Zcash serialization (the one used for IETF BLS spec) the bit is set to 1 if y > -y. Which means that y > q/2.

https://github.com/zkcrypto/pairing/blob/master/src/bls12_381/README.md#serialization