### PR TITLE
Fix edge case in ep2_pck according to IETF spec, and add comment to e…

### DIFF
--- a/src/ep/relic_ep_pck.c
+++ b/src/ep/relic_ep_pck.c
@@ -90,15 +90,18 @@ int ep_upk(ep_t r, const ep_t p) {
 
 		if (result) {
 			/* Verify whether the y coordinate is the larger one, matches the
-			 * compressed y-coordinate. */
+			 * compressed y-coordinate, from IETF pairing friendly spec:
+				sign_F_p(y) :=  { 1 if y > (p - 1) / 2, else
+								{ 0 otherwise.
+			*/
 			halfQ->used = RLC_FP_DIGS;
 			dv_copy(halfQ->dp, fp_prime_get(), RLC_FP_DIGS);
-			bn_hlv(halfQ, halfQ);
+			bn_hlv(halfQ, halfQ);  // This is equivalent to p - 1 / 2, floor division
 
 			fp_prime_back(yValue, t);
-			int b = bn_cmp(yValue, halfQ) == RLC_GT;
+			int sign_fpy = bn_cmp(yValue, halfQ) == RLC_GT;
 
-			if (b != fp_get_bit(p->y, 0)) {
+			if (sign_fpy != fp_get_bit(p->y, 0)) {
 				fp_neg(t, t);
 			}
 			fp_copy(r->x, p->x);

--- a/src/epx/relic_ep2_pck.c
+++ b/src/epx/relic_ep2_pck.c
@@ -92,16 +92,25 @@ int ep2_upk(ep2_t r, ep2_t p) {
 
 		if (result) {
 			/* Verify whether the y coordinate is the larger one, matches the
-			 * compressed y-coordinate. */
+			 * compressed y-coordinate (IETF pairing friendly spec)
+			 * sign_F_p^2(y') := { sign_F_p(y'_0) if y'_1 equals 0, else
+			 *          	     { 1 if y'_1 > (p - 1) / 2, else
+			 *                   { 0 otherwise.
+			 *
+			 */
 			halfQ->used = RLC_FP_DIGS;
 			dv_copy(halfQ->dp, fp_prime_get(), RLC_FP_DIGS);
 			bn_hlv(halfQ, halfQ);
 
 			fp_prime_back(yValue, t[1]);
 
-			int b = bn_cmp(yValue, halfQ) == RLC_GT;
+			if (bn_is_zero(yValue)) {
+				fp_prime_back(yValue, t[0]);
+			}
 
-			if (b != fp_get_bit(p->y[0], 0)) {
+			int sign_fp2y = bn_cmp(yValue, halfQ) == RLC_GT;
+
+			if (sign_fp2y != fp_get_bit(p->y[0], 0)) {
 				fp2_neg(t, t);
 			}
 			fp2_copy(r->x, p->x);


### PR DESCRIPTION
In page 48 of the [pairing friendly curves spec](https://datatracker.ietf.org/doc/draft-irtf-cfrg-pairing-friendly-curves/?include_text=1) The serialization routine points out the edge case where the g2 y coordinate (y0, y1) has y1==0, y0 should be used instead to determine the compressed bit. (This means that for any point A other than infinity, A and -A will be guaranteed to have a different serialization). 

Also some comments added to ep_pck.