### PR TITLE
Optimize some Montgomery reduction steps

### DIFF
--- a/src/fp/relic_fp_prime.c
+++ b/src/fp/relic_fp_prime.c
@@ -45,7 +45,6 @@
  * @param[in] p			- the new prime field modulus.
  */
 static void fp_prime_set(const bn_t p) {
-	dv_t s, q;
 	bn_t t;
 	fp_t r;
 	ctx_t *ctx = core_get();
@@ -54,9 +53,7 @@ static void fp_prime_set(const bn_t p) {
 		RLC_THROW(ERR_NO_VALID);
 	}
 
-	dv_null(s);
 	bn_null(t);
-	dv_null(q);
 	fp_null(r);
 
 	RLC_TRY {
@@ -71,17 +68,19 @@ static void fp_prime_set(const bn_t p) {
 
 		bn_mod_pre_monty(t, &(ctx->prime));
 		ctx->u = t->dp[0];
-		dv_zero(s, 2 * RLC_FP_DIGS);
-		s[2 * RLC_FP_DIGS] = 1;
-		dv_zero(q, 2 * RLC_FP_DIGS + 1);
-		dv_copy(q, ctx->prime.dp, RLC_FP_DIGS);
-		bn_divn_low(t->dp, ctx->conv.dp, s, 2 * RLC_FP_DIGS + 1, q, RLC_FP_DIGS);
-		ctx->conv.used = RLC_FP_DIGS;
-		bn_trim(&(ctx->conv));
+
+		/* compute R mod p */
 		bn_set_dig(&(ctx->one), 1);
 		bn_lsh(&(ctx->one), &(ctx->one), ctx->prime.used * RLC_DIG);
 		bn_mod(&(ctx->one), &(ctx->one), &(ctx->prime));
 
+		/* compute the R^2 mod p */
+		fp_add(r, ctx->one.dp, ctx->one.dp);
+		bn_set_dig(t, RLC_FP_DIGS * RLC_DIG);
+		fp_exp(ctx->conv.dp, r, t );
+		ctx->conv.used = RLC_FP_DIGS;
+		bn_trim(&(ctx->conv));
+	
 		#endif /* FP_RDC == MONTY */
 
 		/* Now look for proper quadratic/cubic non-residues. */
@@ -137,8 +136,6 @@ static void fp_prime_set(const bn_t p) {
 	}
 	RLC_FINALLY {
 		bn_free(t);
-		dv_free(s);
-		dv_free(q);
 		fp_free(r);
 	}
 }
@@ -476,7 +473,7 @@ void fp_prime_conv(fp_t c, const bn_t a) {
 
 		bn_mod(t, a, &(core_get()->prime));
 #if FP_RDC == MONTY
-		fp_mul(c, t->dp, (core_get()->conv).dp);
+		fp_mul(c, t->dp, core_get()->conv.dp);
 #else
 		if (bn_is_zero(t)) {
 			fp_zero(c);

--- a/src/fp/relic_fp_prime.c
+++ b/src/fp/relic_fp_prime.c
@@ -476,9 +476,7 @@ void fp_prime_conv(fp_t c, const bn_t a) {
 
 		bn_mod(t, a, &(core_get()->prime));
 #if FP_RDC == MONTY
-		bn_lsh(t, t, RLC_FP_DIGS * RLC_DIG);
-		bn_mod(t, t, &(core_get()->prime));
-		dv_copy(c, t->dp, RLC_FP_DIGS);
+		fp_mul(c, t->dp, (core_get()->conv).dp);
 #else
 		if (bn_is_zero(t)) {
 			fp_zero(c);

--- a/test/test_fp.c
+++ b/test/test_fp.c
@@ -67,7 +67,7 @@ static int util(void) {
 	char str[RLC_FP_BITS + 2];
 	uint8_t bin[RLC_FP_BYTES];
 	fp_t a, b;
-	bn_t c;
+	bn_t c, e;
 	dig_t d;
 
 	fp_null(a);
@@ -78,6 +78,7 @@ static int util(void) {
 		fp_new(a);
 		fp_new(b);
 		bn_new(c);
+		bn_new(e);
 
 		TEST_BEGIN("copy and comparison are consistent") {
 			fp_rand(a);
@@ -167,6 +168,19 @@ static int util(void) {
 			TEST_ASSERT(fp_size_str(a, 2) == (1 + bn_bits(c)), end);
 		}
 		TEST_END;
+
+		TEST_BEGIN("converting to and from a prime field element are consistent") {
+			bn_rand(c, RLC_POS, RLC_FP_DIGS * RLC_DIG);
+			bn_mod_basic(c, c, &core_get()->prime);
+			fp_prime_conv(a, c);
+			fp_prime_back(e, a);
+			TEST_ASSERT(bn_cmp(c, e) == RLC_EQ, end);
+
+			fp_prime_conv_dig(a, c->dp[0]);
+			fp_prime_back(e, a);
+			TEST_ASSERT(bn_cmp_dig(e, c->dp[0]) == RLC_EQ, end);
+		}
+		TEST_END;
 	}
 	RLC_CATCH_ANY {
 		RLC_ERROR(end);
@@ -176,6 +190,7 @@ static int util(void) {
 	fp_free(a);
 	fp_free(b);
 	bn_free(c);
+	bn_free(e);
 	return code;
 }
 


### PR DESCRIPTION
This PR optimizes some computation steps when Montgomery reduction is used.

It makes the following changes:

 - `fp_prime_conv`: converting to `fp` uses an `fp`-multiplication by `R^2 mod p` instead of the shift and reduction.
 -  adding a test to check the consistency of `fp_prime_conv` and `fp_prime_back`.
 - `fp_prime_init` : computing `R^2 mod p` is done more efficiently by converting the constant 2 to `fp` and using an `fp`-exponentiation by the bit-size of `R`. 
