### PR TITLE
Fix MinGW build

### DIFF
--- a/include/relic_alloc.h
+++ b/include/relic_alloc.h
@@ -31,7 +31,7 @@
 
 #include "relic_conf.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 
 #include <malloc.h>
 

--- a/include/relic_alloc.h
+++ b/include/relic_alloc.h
@@ -31,7 +31,7 @@
 
 #include "relic_conf.h"
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
 
 #include <malloc.h>
 

--- a/src/rand/relic_rand_core.c
+++ b/src/rand/relic_rand_core.c
@@ -54,7 +54,7 @@
 #undef DOUBLE
 
 #include <windows.h>
-#include <Wincrypt.h>
+#include <wincrypt.h>
 
 #elif SEED == RDRND
 


### PR DESCRIPTION
I didn't test a521e8b but i assume its also required since 8c1c1fd is required because there is no `alloca.h` in win/mingw.

Also it doesn't seem to like includes starting with upper-case, hence 11b1f42.