### PR TITLE
TLS for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ message(STATUS "Supported multithreading APIs (default = UNDEF):\n")
 message("   MULTI=         No multithreading support.")
 message("   MULTI=OPENMP   Open Multi-Processing.")
 message("   MULTI=PTHREAD  POSIX threads.\n")
+message("   MULTI=MSVCTLS  MSVC TLS threads.\n")
 
 message(STATUS "Supported timers (default = HREAL):\n")
 
@@ -274,6 +275,9 @@ else()
 		find_package(Threads REQUIRED)
 		set(CFLAGS "${CFLAGS} -pthread")
 		set(MULTI "PTHREAD" CACHE STRING "Multithreading interface")
+	endif()
+	if(MULTI STREQUAL MSVCTLS)
+		set(MULTI "MSVCTLS" CACHE STRING "Multithreading interface")
 	endif()
 endif()
 

--- a/include/relic_conf.h.in
+++ b/include/relic_conf.h.in
@@ -680,6 +680,8 @@
 #define OPENMP   1
 /** POSIX multithreading support. */
 #define PTHREAD  2
+/** MSVC TLS multithreading support. */
+#define MSVCTLS  3
 /** Chosen multithreading API. */
 #cmakedefine MULTI    @MULTI@
 

--- a/include/relic_multi.h
+++ b/include/relic_multi.h
@@ -56,6 +56,8 @@
  */
 #if MULTI == PTHREAD
 #define rlc_thread 	__thread
+#elif MULTI == MSVCTLS
+#define rlc_thread 	__declspec( thread )
 #else
 #define rlc_thread /* */
 #endif


### PR DESCRIPTION
added an option for the use of MSVC thread-local storage which works the same as pthread.

As a separate/motivating issue, it appears that OpenMP broken on windows. Complains about `first_ctx, core_ctx` in `#pragma omp threadprivate(first_ctx, core_ctx)` needing to be global variables (which they are, so IDK).