### PR TITLE
Add a direct field-to-curve map

### DIFF
--- a/include/relic_ep.h
+++ b/include/relic_ep.h
@@ -1192,6 +1192,18 @@ void ep_norm(ep_t r, const ep_t p);
 void ep_norm_sim(ep_t *r, const ep_t *t, int n);
 
 /**
+ * Maps an array of uniformly random bytes to a point in a prime elliptic
+ * curve.
+ * That array is expected to have a length suitable for two field elements plus
+ * extra bytes for uniformity.
+  *
+ * @param[out] p			- the result.
+ * @param[in] uniform_bytes		- the array of uniform bytes to map.
+ * @param[in] len			- the array length in bytes.
+ */
+void ep_map_from_field(ep_t p, const uint8_t *uniform_bytes, int len);
+
+/**
  * Maps a byte array to a point in a prime elliptic curve.
  *
  * @param[out] p			- the result.

--- a/include/relic_ep.h
+++ b/include/relic_ep.h
@@ -1201,19 +1201,6 @@ void ep_norm_sim(ep_t *r, const ep_t *t, int n);
 void ep_map(ep_t p, const uint8_t *msg, int len);
 
 /**
- * Maps a byte array to a point in a prime elliptic curve using
- * an explicit domain separation tag.
- *
- * @param[out] p			- the result.
- * @param[in] msg			- the byte array to map.
- * @param[in] len			- the array length in bytes.
- * @param[in] dst			- the domain separation tag.
- * @param[in] dst_len		- the domain separation tag length in bytes.
- */
-void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst,
-		int dst_len);
-
-/**
  * Maps a byte array to a point in a prime elliptic curve with specified
  * domain separation tag (aka personalization string).
  *

--- a/include/relic_epx.h
+++ b/include/relic_epx.h
@@ -1125,6 +1125,18 @@ void ep2_norm(ep2_t r, ep2_t p);
 void ep2_norm_sim(ep2_t *r, ep2_t *t, int n);
 
 /**
+ * Maps an array of uniformly random bytes to a point in a prime elliptic
+ * curve.
+ * That array is expected to have a length suitable for four field elements plus
+ * extra bytes for uniformity.
+  *
+ * @param[out] p			- the result.
+ * @param[in] uniform_bytes		- the array of uniform bytes to map.
+ * @param[in] len			- the array length in bytes.
+ */
+void ep2_map_from_field(ep2_t p, const uint8_t *uniform_bytes, int len);
+
+/**
  * Maps a byte array to a point in an elliptic curve over a quadratic extension.
  *
  * @param[out] p			- the result.

--- a/src/ep/relic_ep_map.c
+++ b/src/ep/relic_ep_map.c
@@ -80,112 +80,135 @@ static inline int fp_sgn0(const fp_t t, bn_t k) {
 /* Public definitions                                                         */
 /*============================================================================*/
 
-void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
-	bn_t k;
-	fp_t t;
-	ep_t q;
-	int neg;
-	/* enough space for two field elements plus extra bytes for uniformity */
-	const int len_per_elm = (FP_PRIME + ep_param_level() + 7) / 8;
-	uint8_t *pseudo_random_bytes = RLC_ALLOCA(uint8_t, 2 * len_per_elm);
 
-	bn_null(k);
-	fp_null(t);
-	ep_null(q);
+void ep_map_from_field(ep_t p, const uint8_t *uniform_bytes, int len) {
+  bn_t k;
+  fp_t t;
+  ep_t q;
+  int neg;
+  /* enough space for two field elements plus extra bytes for uniformity */
+  const int len_per_elm = (FP_PRIME + ep_param_level() + 7) / 8;
 
-	RLC_TRY {
-		bn_new(k);
-		fp_new(t);
-		ep_new(q);
+  bn_null(k);
+  fp_null(t);
+  ep_null(q);
 
-		/* figure out which hash function to use */
-		const int abNeq0 = (ep_curve_opt_a() != RLC_ZERO) && (ep_curve_opt_b() != RLC_ZERO);
-		void (*const map_fn)(ep_t, fp_t) = (ep_curve_is_ctmap() || abNeq0) ? ep_map_sswu : ep_map_svdw;
+  RLC_TRY {
+    if (len != 2* len_per_elm) {
+      RLC_THROW(ERR_NO_VALID);
+    }
 
-		/* for hash_to_field, need to hash to a pseudorandom string */
-		/* XXX(rsw) the below assumes that we want to use MD_MAP for hashing.
-		 *          Consider making the hash function a per-curve option!
-		 */
-		md_xmd(pseudo_random_bytes, 2 * len_per_elm, msg, len, dst, dst_len);
+    bn_new(k);
+    fp_new(t);
+    ep_new(q);
 
-#define EP_MAP_CONVERT_BYTES(IDX)                                              \
-	do {                                                                       \
-		bn_read_bin(k, pseudo_random_bytes + IDX * len_per_elm, len_per_elm);  \
-		fp_prime_conv(t, k);                                                   \
-	} while (0)
+    /* figure out which hash function to use */
+    const int abNeq0 = (ep_curve_opt_a() != RLC_ZERO) && (ep_curve_opt_b() != RLC_ZERO);
+    void (*const map_fn)(ep_t, fp_t) = (ep_curve_is_ctmap() || abNeq0) ? ep_map_sswu : ep_map_svdw;
 
-#define EP_MAP_APPLY_MAP(PT)                                                   \
-	do {                                                                       \
-		/* check sign of t */                                                  \
-		neg = fp_sgn0(t, k);                                                   \
-		/* convert */                                                          \
-		map_fn(PT, t);                                                         \
-		/* compare sign of y and sign of t; fix if necessary */                \
-		neg = neg != fp_sgn0(PT->y, k);                                        \
-		fp_neg(t, PT->y);                                                      \
-		dv_copy_cond(PT->y, t, RLC_FP_DIGS, neg);                              \
-	} while (0)
+#define EP_MAP_CONVERT_BYTES(IDX)                                       \
+    do {                                                                \
+      bn_read_bin(k, uniform_bytes + IDX * len_per_elm, len_per_elm);   \
+      fp_prime_conv(t, k);                                              \
+    } while (0)
 
-		/* first map invocation */
-		EP_MAP_CONVERT_BYTES(0);
-		EP_MAP_APPLY_MAP(p);
-		TMPL_MAP_CALL_ISOMAP(ep, p);
+#define EP_MAP_APPLY_MAP(PT)                                    \
+    do {                                                        \
+      /* check sign of t */                                     \
+      neg = fp_sgn0(t, k);                                      \
+      /* convert */                                             \
+      map_fn(PT, t);                                            \
+      /* compare sign of y and sign of t; fix if necessary */   \
+      neg = neg != fp_sgn0(PT->y, k);                             \
+      fp_neg(t, PT->y);                                          \
+      dv_copy_cond(PT->y, t, RLC_FP_DIGS, neg);                  \
+    } while (0)
 
-		/* second map invocation */
-		EP_MAP_CONVERT_BYTES(1);
-		EP_MAP_APPLY_MAP(q);
-		TMPL_MAP_CALL_ISOMAP(ep, q);
+    /* first map invocation */
+    EP_MAP_CONVERT_BYTES(0);
+    EP_MAP_APPLY_MAP(p);
+    TMPL_MAP_CALL_ISOMAP(ep, p);
 
-		/* XXX(rsw) could add p and q and then apply isomap,
-		 * but need ep_add to support addition on isogeny curves */
+    /* second map invocation */
+    EP_MAP_CONVERT_BYTES(1);
+    EP_MAP_APPLY_MAP(q);
+    TMPL_MAP_CALL_ISOMAP(ep, q);
+
+    /* XXX(rsw) could add p and q and then apply isomap,
+     * but need ep_add to support addition on isogeny curves */
 
 #undef EP_MAP_CONVERT_BYTES
 #undef EP_MAP_APPLY_MAP
 
-		/* sum the result */
-		ep_add(p, p, q);
-		ep_norm(p, p);
+    /* sum the result */
+    ep_add(p, p, q);
+    ep_norm(p, p);
 
-		/* clear cofactor */
-		switch (ep_curve_is_pairf()) {
-			case EP_BN:
-				/* h = 1 */
-				break;
-			case EP_B12:
-			case EP_B24:
-				/* multiply by 1-x (x the BLS parameter) to get the correct group. */
-				/* XXX(rsw) is this guaranteed to work? It could fail if one
-				 *          of the prime-squared subgroups is cyclic, but
-				 *          maybe there's an argument that this is never the case...
-				 */
-				fp_prime_get_par(k);
-				bn_neg(k, k);
-				bn_add_dig(k, k, 1);
-				if (bn_bits(k) < RLC_DIG) {
-					ep_mul_dig(p, p, k->dp[0]);
-				} else {
-					ep_mul(p, p, k);
-				}
-				break;
-			default:
-				/* multiply by cofactor to get the correct group. */
-				ep_curve_get_cof(k);
-				if (bn_bits(k) < RLC_DIG) {
-					ep_mul_dig(p, p, k->dp[0]);
-				} else {
-					ep_mul_basic(p, p, k);
-				}
-		}
-	}
-	RLC_CATCH_ANY {
-		RLC_THROW(ERR_CAUGHT);
-	}
-	RLC_FINALLY {
-		bn_free(k);
-		fp_free(t);
-		ep_free(q);
-		RLC_FREE(pseudo_random_bytes);
-	}
+    /* clear cofactor */
+    switch (ep_curve_is_pairf()) {
+    case EP_BN:
+      /* h = 1 */
+      break;
+    case EP_B12:
+    case EP_B24:
+      /* multiply by 1-x (x the BLS parameter) to get the correct group. */
+      /* XXX(rsw) is this guaranteed to work? It could fail if one
+       *          of the prime-squared subgroups is cyclic, but
+       *          maybe there's an argument that this is never the case...
+       */
+      fp_prime_get_par(k);
+      bn_neg(k, k);
+      bn_add_dig(k, k, 1);
+      if (bn_bits(k) < RLC_DIG) {
+        ep_mul_dig(p, p, k->dp[0]);
+      } else {
+        ep_mul(p, p, k);
+      }
+      break;
+    default:
+      /* multiply by cofactor to get the correct group. */
+      ep_curve_get_cof(k);
+      if (bn_bits(k) < RLC_DIG) {
+        ep_mul_dig(p, p, k->dp[0]);
+      } else {
+        ep_mul_basic(p, p, k);
+      }
+    }
+  }
+  RLC_CATCH_ANY {
+    RLC_THROW(ERR_CAUGHT);
+  }
+  RLC_FINALLY {
+    bn_free(k);
+    fp_free(t);
+    ep_free(q);
+  }
+
+}
+
+
+void ep_map_dst(ep_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
+
+  /* enough space for two field elements plus extra bytes for uniformity */
+  const int len_per_elm = (FP_PRIME + ep_param_level() + 7) / 8;
+  uint8_t *pseudo_random_bytes = RLC_ALLOCA(uint8_t, 2 * len_per_elm);
+
+  RLC_TRY {
+
+    /* for hash_to_field, need to hash to a pseudorandom string */
+    /* XXX(rsw) the below assumes that we want to use MD_MAP for hashing.
+     *          Consider making the hash function a per-curve option!
+     */
+    md_xmd(pseudo_random_bytes, 2 * len_per_elm, msg, len, dst, dst_len);
+    ep_map_from_field(p, pseudo_random_bytes, 2 * len_per_elm);
+  }
+  RLC_CATCH_ANY {
+    RLC_THROW(ERR_CAUGHT);
+  }
+  RLC_FINALLY {
+    RLC_FREE(pseudo_random_bytes);
+  }
+
 }
 
 void ep_map(ep_t p, const uint8_t *msg, int len) {

--- a/src/epx/relic_ep2_map.c
+++ b/src/epx/relic_ep2_map.c
@@ -89,83 +89,103 @@ static inline int fp2_sgn0(const fp2_t t, bn_t k) {
 /* Public definitions                                                         */
 /*============================================================================*/
 
-void ep2_map_dst(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
-	bn_t k;
-	fp2_t t;
-	ep2_t q;
-	int neg;
-	/* enough space for two extension field elements plus extra bytes for uniformity */
-	const int len_per_elm = (FP_PRIME + ep_param_level() + 7) / 8;
-	uint8_t *pseudo_random_bytes = RLC_ALLOCA(uint8_t, 4 * len_per_elm);
+void ep2_map_from_field(ep2_t p, const uint8_t *uniform_bytes, int len) {
+        bn_t k;
+        fp2_t t;
+        ep2_t q;
+        int neg;
+        /* enough space for two extension field elements plus extra bytes for uniformity */
+        const int len_per_elm = (FP_PRIME + ep_param_level() + 7) / 8;
 
-	bn_null(k);
-	fp2_null(t);
-	ep2_null(q);
+        bn_null(k);
+        fp2_null(t);
+        ep2_null(q);
 
-	RLC_TRY {
-		bn_new(k);
-		fp2_new(t);
-		ep2_new(q);
+        RLC_TRY {
+                if (len != 2* len_per_elm) {
+                  RLC_THROW(ERR_NO_VALID);
+                }
 
-		/* which hash function should we use? */
-		const int abNeq0 = (ep2_curve_opt_a() != RLC_ZERO) && (ep2_curve_opt_b() != RLC_ZERO);
-		void (*const map_fn)(ep2_t, fp2_t) = (ep2_curve_is_ctmap() || abNeq0) ? ep2_map_sswu : ep2_map_svdw;
+                bn_new(k);
+                fp2_new(t);
+                ep2_new(q);
 
-		/* XXX(rsw) See note in ep/relic_ep_map.c about using MD_MAP. */
-		/* hash to a pseudorandom string using md_xmd */
-		md_xmd(pseudo_random_bytes, 4 * len_per_elm, msg, len, dst, dst_len);
+                /* which hash function should we use? */
+                const int abNeq0 = (ep2_curve_opt_a() != RLC_ZERO) && (ep2_curve_opt_b() != RLC_ZERO);
+                void (*const map_fn)(ep2_t, fp2_t) = (ep2_curve_is_ctmap() || abNeq0) ? ep2_map_sswu : ep2_map_svdw;
 
 #define EP2_MAP_CONVERT_BYTES(IDX)                                                       \
-	do {                                                                                 \
-		bn_read_bin(k, pseudo_random_bytes + 2 * IDX * len_per_elm, len_per_elm);        \
-		fp_prime_conv(t[0], k);                                                          \
-		bn_read_bin(k, pseudo_random_bytes + (2 * IDX + 1) * len_per_elm, len_per_elm);  \
-		fp_prime_conv(t[1], k);                                                          \
-	} while (0)
+        do {                                                                                 \
+                bn_read_bin(k, uniform_bytes + 2 * IDX * len_per_elm, len_per_elm);        \
+                fp_prime_conv(t[0], k);                                                          \
+                bn_read_bin(k, uniform_bytes + (2 * IDX + 1) * len_per_elm, len_per_elm);  \
+                fp_prime_conv(t[1], k);                                                          \
+        } while (0)
 
 #define EP2_MAP_APPLY_MAP(PT)                                                            \
-	do {                                                                                 \
-		/* sign of t */                                                                  \
-		neg = fp2_sgn0(t, k);                                                            \
-		/* convert */                                                                    \
-		map_fn(PT, t);                                                                   \
-		/* compare sign of y to sign of t; fix if necessary */                           \
-		neg = neg != fp2_sgn0(PT->y, k);                                                 \
-		fp2_neg(t, PT->y);                                                               \
-		dv_copy_cond(PT->y[0], t[0], RLC_FP_DIGS, neg);                                  \
-		dv_copy_cond(PT->y[1], t[1], RLC_FP_DIGS, neg);                                  \
-	} while (0)
+        do {                                                                                 \
+                /* sign of t */                                                                  \
+                neg = fp2_sgn0(t, k);                                                            \
+                /* convert */                                                                    \
+                map_fn(PT, t);                                                                   \
+                /* compare sign of y to sign of t; fix if necessary */                           \
+                neg = neg != fp2_sgn0(PT->y, k);                                                 \
+                fp2_neg(t, PT->y);                                                               \
+                dv_copy_cond(PT->y[0], t[0], RLC_FP_DIGS, neg);                                  \
+                dv_copy_cond(PT->y[1], t[1], RLC_FP_DIGS, neg);                                  \
+        } while (0)
 
-		/* first map invocation */
-		EP2_MAP_CONVERT_BYTES(0);
-		EP2_MAP_APPLY_MAP(p);
-		TMPL_MAP_CALL_ISOMAP(ep2, p);
+                /* first map invocation */
+                EP2_MAP_CONVERT_BYTES(0);
+                EP2_MAP_APPLY_MAP(p);
+                TMPL_MAP_CALL_ISOMAP(ep2, p);
 
-		/* second map invocation */
-		EP2_MAP_CONVERT_BYTES(1);
-		EP2_MAP_APPLY_MAP(q);
-		TMPL_MAP_CALL_ISOMAP(ep2, q);
+                /* second map invocation */
+                EP2_MAP_CONVERT_BYTES(1);
+                EP2_MAP_APPLY_MAP(q);
+                TMPL_MAP_CALL_ISOMAP(ep2, q);
 
-		/* XXX(rsw) could add p and q and then apply isomap,
-		 * but need ep_add to support addition on isogeny curves */
+                /* XXX(rsw) could add p and q and then apply isomap,
+                 * but need ep_add to support addition on isogeny curves */
 
 #undef EP2_MAP_CONVERT_BYTES
 #undef EP2_MAP_APPLY_MAP
 
-		/* sum the result */
-		ep2_add(p, p, q);
-		ep2_norm(p, p);
-		ep2_mul_cof(p, p);
-	}
-	RLC_CATCH_ANY {
-		RLC_THROW(ERR_CAUGHT);
-	}
-	RLC_FINALLY {
-		bn_free(k);
-		fp2_free(t);
-		ep2_free(q);
-		RLC_FREE(pseudo_random_bytes);
-	}
+                /* sum the result */
+                ep2_add(p, p, q);
+                ep2_norm(p, p);
+                ep2_mul_cof(p, p);
+        }
+        RLC_CATCH_ANY {
+                RLC_THROW(ERR_CAUGHT);
+        }
+        RLC_FINALLY {
+                bn_free(k);
+                fp2_free(t);
+                ep2_free(q);
+        }
+}
+
+
+void ep2_map_dst(ep2_t p, const uint8_t *msg, int len, const uint8_t *dst, int dst_len) {
+
+        /* enough space for two field elements plus extra bytes for uniformity */
+        const int len_per_elm = (FP_PRIME + ep_param_level() + 7) / 8;
+        uint8_t *pseudo_random_bytes = RLC_ALLOCA(uint8_t, 4 * len_per_elm);
+
+        RLC_TRY {
+
+                /* XXX(rsw) See note in ep/relic_ep_map.c about using MD_MAP. */
+                /* hash to a pseudorandom string using md_xmd */
+                md_xmd(pseudo_random_bytes, 4 * len_per_elm, msg, len, dst, dst_len);
+                ep2_map_from_field(p, pseudo_random_bytes, 2 * len_per_elm);
+        }
+        RLC_CATCH_ANY {
+                RLC_THROW(ERR_CAUGHT);
+        }
+        RLC_FINALLY {
+                RLC_FREE(pseudo_random_bytes);
+        }
 }
 
 void ep2_map(ep2_t p, const uint8_t *msg, int len) {


### PR DESCRIPTION
The set of admissible hash-to-field functions in the [draft hash-to-curve RFC](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11) now far exceeds what's available md_xmd,
may exceed what is reasonable for Relic to implement, and will not include the customization described in [5.4.4](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-hash-to-curve-11#section-5.4.4).

As a consequence, this adds an API for accessing the map-to-curve mapping from pre-hashed bytes of the correct size.
