### PR TITLE
Fix NETBSD definition

### DIFF
--- a/include/relic_conf.h.in
+++ b/include/relic_conf.h.in
@@ -671,8 +671,8 @@
 #define DROID    5
 /** Arduino platform. */
 #define DUINO    6
-/** OpenBSD operating system. */
-#define OPENBSD  7
+/** NetBSD operating system. */
+#define NETBSD  7
 /** Detected operation system. */
 #cmakedefine OPSYS    @OPSYS@
 


### PR DESCRIPTION
I removed the macro definition of OPENBSD that is not referenced anywhere else in the code and added NETBSD that is indeed referenced but never defined