### PR TITLE
Minor permutation optimization

### DIFF
--- a/src/relic_util.c
+++ b/src/relic_util.c
@@ -154,16 +154,11 @@ int util_cmp_const(const void *a, const void *b, int size) {
 void util_perm(unsigned int p[], int n) {
 	size_t i, j, k;
 
-	for (i = 0; i < n; i++) {
-		p[i] = i;
-	}
-
 	for (i = 0; i < n - 1; i++) {
 		rand_bytes((uint8_t *)&k, sizeof(size_t));
-		j = i + (k % (n - i));
-		if (i != j) {
-			RLC_SWAP(p[i], p[j]);
-		}
+		j = k % (i+1);
+		p[i] = p[j];
+		p[j] = i;
 	}
 }
 

--- a/src/relic_util.c
+++ b/src/relic_util.c
@@ -154,7 +154,7 @@ int util_cmp_const(const void *a, const void *b, int size) {
 void util_perm(unsigned int p[], int n) {
 	size_t i, j, k;
 
-	for (i = 0; i < n - 1; i++) {
+	for (i = 0; i < n; i++) {
 		rand_bytes((uint8_t *)&k, sizeof(size_t));
 		j = k % (i+1);
 		p[i] = p[j];


### PR DESCRIPTION
Optimize the permutation function by merging the array initialization step into the permutation.
([inside-out version](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_%22inside-out%22_algorithm) of Fisher-Yates)

(please feel free to make any updates to the PR before merging) 