### PR TITLE
STRIP on fix

### DIFF
--- a/src/ep/relic_ep_mul.c
+++ b/src/ep/relic_ep_mul.c
@@ -670,8 +670,6 @@ void ep_mul_lwnaf(ep_t r, const ep_t p, const bn_t k) {
 
 #endif
 
-#if EP_MUL == LWREG || !defined(STRIP)
-
 void ep_mul_lwreg(ep_t r, const ep_t p, const bn_t k) {
 	if (bn_is_zero(k) || ep_is_infty(p)) {
 		ep_set_infty(r);
@@ -689,8 +687,6 @@ void ep_mul_lwreg(ep_t r, const ep_t p, const bn_t k) {
 	ep_mul_reg_imp(r, p, k);
 #endif
 }
-
-#endif
 
 void ep_mul_gen(ep_t r, const bn_t k) {
 	if (bn_is_zero(k)) {

--- a/src/ep/relic_ep_mul.c
+++ b/src/ep/relic_ep_mul.c
@@ -35,7 +35,6 @@
 /* Private definitions                                                        */
 /*============================================================================*/
 
-#if EP_MUL == LWNAF || !defined(STRIP)
 
 #if defined(EP_ENDOM)
 
@@ -212,9 +211,7 @@ static void ep_mul_naf_imp(ep_t r, const ep_t p, const bn_t k) {
 }
 
 #endif /* EP_PLAIN || EP_SUPER */
-#endif /* EP_MUL == LWNAF */
 
-#if EP_MUL == LWREG || !defined(STRIP)
 
 #if defined(EP_ENDOM)
 
@@ -457,7 +454,6 @@ static void ep_mul_reg_imp(ep_t r, const ep_t p, const bn_t k) {
 }
 
 #endif /* EP_PLAIN || EP_SUPER */
-#endif /* EP_MUL == LWNAF */
 
 /*============================================================================*/
 /* Public definitions                                                         */

--- a/src/epx/relic_ep2_norm.c
+++ b/src/epx/relic_ep2_norm.c
@@ -32,12 +32,6 @@
 
 #include "relic_core.h"
 
-/*============================================================================*/
-/* Private definitions                                                        */
-/*============================================================================*/
-
-#if EP_ADD == PROJC || !defined(STRIP)
-
 /**
  * Normalizes a point represented in projective coordinates.
  *
@@ -78,12 +72,6 @@ static void ep2_norm_imp(ep2_t r, const ep2_t p, int inverted) {
 
 	r->coord = BASIC;
 }
-
-#endif /* EP_ADD == PROJC */
-
-/*============================================================================*/
-/* Public definitions                                                         */
-/*============================================================================*/
 
 void ep2_norm(ep2_t r, const ep2_t p) {
 	if (ep2_is_infty(p)) {

--- a/src/epx/relic_ep4_norm.c
+++ b/src/epx/relic_ep4_norm.c
@@ -32,12 +32,6 @@
 
 #include "relic_core.h"
 
-/*============================================================================*/
-/* Private definitions                                                        */
-/*============================================================================*/
-
-#if EP_ADD == PROJC || !defined(STRIP)
-
 /**
  * Normalizes a point represented in projective coordinates.
  *
@@ -78,12 +72,6 @@ static void ep4_norm_imp(ep4_t r, const ep4_t p, int inverted) {
 
 	r->coord = BASIC;
 }
-
-#endif /* EP_ADD == PROJC */
-
-/*============================================================================*/
-/* Public definitions                                                         */
-/*============================================================================*/
 
 void ep4_norm(ep4_t r, const ep4_t p) {
 	if (ep4_is_infty(p)) {

--- a/src/fpx/relic_fp24_sqr.c
+++ b/src/fpx/relic_fp24_sqr.c
@@ -37,7 +37,8 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if FPX_RDC == BASIC || !defined(STRIP)
+//TODO: Remove the FPX_RDX == LAZYR from below condition once lazy reduction has been implemented
+#if FPX_RDC == BASIC || FPX_RDC == LAZYR || !defined(STRIP)
 
 void fp24_sqr_basic(fp24_t c, const fp24_t a) {
 	fp8_t t0, t1, t2, t3, t4;

--- a/src/fpx/relic_fp48_mul.c
+++ b/src/fpx/relic_fp48_mul.c
@@ -37,7 +37,8 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if FPX_RDC == BASIC || !defined(STRIP)
+//TODO: Remove the FPX_RDX == LAZYR from below condition once lazy reduction has been implemented
+#if FPX_RDC == BASIC || FPX_RDC == LAZYR || !defined(STRIP)
 
 void fp48_mul_basic(fp48_t c, const fp48_t a, const fp48_t b) {
 	fp24_t t0, t1, t2;

--- a/src/fpx/relic_fp48_sqr.c
+++ b/src/fpx/relic_fp48_sqr.c
@@ -37,7 +37,8 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if FPX_RDC == BASIC || !defined(STRIP)
+//TODO: Remove the FPX_RDX == LAZYR from below condition once lazy reduction has been implemented
+#if FPX_RDC == BASIC || FPX_RDC == LAZYR || !defined(STRIP)
 
 void fp48_sqr_basic(fp48_t c, const fp48_t a) {
 	fp24_t t0, t1;

--- a/src/fpx/relic_fp54_mul.c
+++ b/src/fpx/relic_fp54_mul.c
@@ -37,7 +37,8 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if FPX_RDC == BASIC || !defined(STRIP)
+//TODO: Remove the FPX_RDX == LAZYR from below condition once lazy reduction has been implemented
+#if FPX_RDC == BASIC || FPX_RDC == LAZYR || !defined(STRIP)
 
 void fp54_mul_basic(fp54_t c, const fp54_t a, const fp54_t b) {
 	fp18_t t0, t1, t2, t3, t4, t5;

--- a/src/fpx/relic_fp54_sqr.c
+++ b/src/fpx/relic_fp54_sqr.c
@@ -37,7 +37,8 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if FPX_RDC == BASIC || !defined(STRIP)
+//TODO: Remove the FPX_RDX == LAZYR from below condition once lazy reduction has been implemented
+#if FPX_RDC == BASIC || FPX_RDC == LAZYR || !defined(STRIP)
 
 void fp54_sqr_basic(fp54_t c, const fp54_t a) {
 	fp18_t t0, t1, t2, t3, t4;

--- a/src/pp/relic_pp_dbl_k24.c
+++ b/src/pp/relic_pp_dbl_k24.c
@@ -37,7 +37,7 @@
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if EP_ADD == PROJC || !defined(STRIP)
+#if EP_ADD == BASIC || !defined(STRIP)
 
 void pp_dbl_k24_basic(fp24_t l, ep4_t r, const ep4_t q, const ep_t p) {
 	fp4_t s;

--- a/src/pp/relic_pp_dbl_k54.c
+++ b/src/pp/relic_pp_dbl_k54.c
@@ -96,7 +96,7 @@ static void ep9_dbl_basic(fp9_t s, fp9_t rx, fp9_t ry) {
 /* Public definitions                                                         */
 /*============================================================================*/
 
-#if EP_ADD == PROJC || !defined(STRIP)
+#if EP_ADD == BASIC || !defined(STRIP)
 
 void pp_dbl_k54_basic(fp54_t l, fp9_t rx, fp9_t ry, const ep_t p) {
 	fp9_t s, tx, ty;

--- a/test/test_ep.c
+++ b/test/test_ep.c
@@ -437,7 +437,7 @@ static int doubling(void) {
 		} TEST_END;
 #endif
 
-#if EP_ADD == PROJC || !defined(STRIP)
+#if EP_ADD == JACOB || !defined(STRIP)
 		TEST_CASE("point doubling in jacobian coordinates is correct") {
 			ep_rand(a);
 			/* a in projective coordinates. */

--- a/test/test_ep.c
+++ b/test/test_ep.c
@@ -537,7 +537,7 @@ static int endomorphism(void) {
 			TEST_END;
 #endif
 
-#if EB_ADD == PROJC || !defined(STRIP)
+#if (EB_ADD == PROJC && EP_ADD == PROJC) || !defined(STRIP)
 			TEST_CASE("endomorphism in projective coordinates is correct") {
 				ep_rand(a);
 				ep_dbl_projc(a, a);

--- a/test/test_pp.c
+++ b/test/test_pp.c
@@ -1734,6 +1734,7 @@ static int doubling48(void) {
 
 		ep_curve_get_ord(n);
 
+#if !defined(STRIP)
 		TEST_CASE("miller doubling is correct") {
 			ep_rand(p);
 			fp8_copy(rx, qx);
@@ -1746,6 +1747,7 @@ static int doubling48(void) {
 			pp_dbl_k48_basic(e2, qx, qy, p);
 			TEST_ASSERT(fp8_cmp(rx, qx) == RLC_EQ && fp8_cmp(ry, qy) == RLC_EQ, end);
 		} TEST_END;
+#endif
 
 #if EP_ADD == BASIC || !defined(STRIP)
 		TEST_CASE("miller doubling in affine coordinates is correct") {
@@ -1873,6 +1875,7 @@ static int addition48(void) {
 
 		ep_curve_get_ord(n);
 
+#if !defined(STRIP)
 		TEST_CASE("miller addition is correct") {
 			ep_rand(p);
 			fp8_copy(rx, qx);
@@ -1897,6 +1900,7 @@ static int addition48(void) {
 			pp_add_k48_basic(e2, rx, ry, qx, qy, p);
 			TEST_ASSERT(fp8_cmp(rx, e1[0][0]) == RLC_EQ && fp8_cmp(ry, e1[0][1]) == RLC_EQ, end);
 		} TEST_END;
+#endif
 
 #if EP_ADD == BASIC || !defined(STRIP)
 		TEST_CASE("miller addition in affine coordinates is correct") {
@@ -1924,7 +1928,7 @@ static int addition48(void) {
 		} TEST_END;
 #endif
 
-#if EP_ADD == BASIC || !defined(STRIP)
+#if !defined(STRIP)
 		TEST_CASE("miller addition in projective coordinates is correct") {
 			ep_rand(p);
 			fp8_copy(rx, qx);
@@ -2130,6 +2134,7 @@ static int doubling54(void) {
 
 		ep_curve_get_ord(n);
 
+#if !defined(STRIP)
 		TEST_CASE("miller doubling is correct") {
 			ep_rand(p);
 			fp9_copy(rx, qx);
@@ -2142,6 +2147,7 @@ static int doubling54(void) {
 			pp_dbl_k54_basic(e2, qx, qy, p);
 			TEST_ASSERT(fp9_cmp(rx, qx) == RLC_EQ && fp9_cmp(ry, qy) == RLC_EQ, end);
 		} TEST_END;
+#endif
 
 #if EP_ADD == BASIC || !defined(STRIP)
 		TEST_CASE("miller doubling in affine coordinates is correct") {
@@ -2271,6 +2277,7 @@ static int addition54(void) {
 
 		ep_curve_get_ord(n);
 
+#if !defined(STRIP)
 		TEST_CASE("miller addition is correct") {
 			ep_rand(p);
 			fp9_copy(rx, qx);
@@ -2295,6 +2302,7 @@ static int addition54(void) {
 			pp_add_k54_basic(e2, rx, ry, qx, qy, p);
 			TEST_ASSERT(fp9_cmp(rx, e1[0][0]) == RLC_EQ && fp9_cmp(ry, e1[0][1]) == RLC_EQ, end);
 		} TEST_END;
+#endif
 
 #if EP_ADD == BASIC || !defined(STRIP)
 		TEST_CASE("miller addition in affine coordinates is correct") {
@@ -2322,7 +2330,7 @@ static int addition54(void) {
 		} TEST_END;
 #endif
 
-#if EP_ADD == BASIC || !defined(STRIP)
+#if !defined(STRIP)
 		TEST_CASE("miller addition in projective coordinates is correct") {
 			ep_rand(p);
 			fp9_copy(rx, qx);


### PR DESCRIPTION
Minor corrections when STRIP is enabled in particular:
- ep2 and ep4 norm_imp should be always defined
- ep_mul_lwreg should be always defined 
- Some tests require STRIP enabled
- fp24_sqr_basic should be defined if FPX_RDC is set to LAZYR (until lazy reduction is implemented)

Minor corrections to define functions with EP_ADD directive.