### PR TITLE
Add support for Chinese national cryptography standard

### DIFF
--- a/include/relic_ep.h
+++ b/include/relic_ep.h
@@ -81,6 +81,8 @@ enum {
 	BSI_P256,
 	/** SECG K-256 prime curve. */
 	SECG_K256,
+	/** SM2 P-256 prime curve. */
+	SM2_P256,
 	/** Curve67254 prime curve. */
 	CURVE_67254,
 	/** Curve383187 prime curve. */

--- a/include/relic_fp.h
+++ b/include/relic_fp.h
@@ -92,6 +92,8 @@ enum {
 	BSI_256,
 	/** SECG 256-bit denser reduction prime. */
 	SECG_256,
+	/** SM2 256-bit prime modulus standardized in China. */
+	SM2_256,
 	/** Curve67254 382-bit prime modulus. */
 	PRIME_382105,
 	/** Curve383187 383-bit prime modulus. */

--- a/src/ep/relic_ep_param.c
+++ b/src/ep/relic_ep_param.c
@@ -252,6 +252,21 @@
 /** @} */
 #endif
 
+#if defined(EP_PLAIN) && FP_PRIME == 256
+/**
+ * Parameters for the SM2 P-256 prime elliptic curve.
+ */
+/** @{ */
+#define SM2_P256_A		"FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00000000FFFFFFFFFFFFFFFC"
+#define SM2_P256_B		"28E9FA9E9D9F5E344D5A9E4BCF6509A7F39789F515AB8F92DDBCBD414D940E93"
+#define SM2_P256_X		"32C4AE2C1F1981195F9904466A39C9948FE30BBFF2660BE1715A4589334C74C7"
+#define SM2_P256_Y		"BC3736A2F4F6779C59BDCEE36B692153D0A9877CC62A474002DF32E52139F0A0"
+#define SM2_P256_R		"FFFFFFFEFFFFFFFFFFFFFFFFFFFFFFFF7203DF6B21C6052B53BBF40939D54123"
+#define SM2_P256_H		"1"
+#define SM2_P256_MAPU	"-A"
+/** @} */
+#endif
+
 #if defined(EP_PLAIN) && FP_PRIME == 382
 /**
  * Parameters for the Curve67254 prime elliptic curve.
@@ -931,6 +946,10 @@ void ep_param_set(int param) {
 				ASSIGN(BSI_P256, BSI_256);
 				plain = 1;
 				break;
+			case SM2_P256:
+				ASSIGN(SM2_P256, SM2_256);
+				plain = 1;
+				break;
 #endif
 #if defined(EP_ENDOM) && FP_PRIME == 256
 			case SECG_K256:
@@ -1501,6 +1520,9 @@ void ep_param_print(void) {
 		case SECG_K256:
 			util_banner("Curve SECG-K256:", 0);
 			break;
+		case SM2_P256:
+			util_banner("Curve SM2-P256:", 0);
+			break;
 		case NIST_P384:
 			util_banner("Curve NIST-P384:", 0);
 			break;
@@ -1610,6 +1632,7 @@ int ep_param_level(void) {
 			return 112;
 		case NIST_P256:
 		case SECG_K256:
+		case SM2_P256:
 		case CURVE_25519:
 		case TWEEDLEDUM:
 			return 128;

--- a/src/fp/relic_fp_param.c
+++ b/src/fp/relic_fp_param.c
@@ -236,6 +236,15 @@ void fp_param_set(int param) {
 				f[7] = 256;
 				fp_prime_set_pmers(f, 8);
 				break;
+			case SM2_256:
+				/* p = 2^256 - 2^224 - 2^96 + 2^64 - 1. */
+				f[0] = -1;
+				f[1] = 64;
+				f[2] = -96;
+				f[3] = -224;
+				f[4] = 256;
+				fp_prime_set_pmers(f, 5);
+				break;
 			case BN_256:
 				/* x = -0x600000000000219B. */
 				bn_set_2b(t0, 62);

--- a/src/pp/relic_pp_exp_k12.c
+++ b/src/pp/relic_pp_exp_k12.c
@@ -125,6 +125,105 @@ static void pp_exp_bn(fp12_t c, fp12_t a) {
 }
 
 /**
+ * Computes the final exponentiation of a pairing defined over 
+ * the SM9 curve.
+ *
+ * @param[out] c			- the result.
+ * @param[in] a				- the extension field element to exponentiate.
+ */
+static void pp_exp_sm9(fp12_t c, fp12_t a) {
+	fp12_t t0, t1, t2, t3, t4, t5, t6, r0, r1;
+	bn_t x;
+	const int *b;
+	int l;
+
+	fp12_null(t0);
+	fp12_null(t1);
+	fp12_null(t2);
+	fp12_null(t3);
+	fp12_null(t4);
+	fp12_null(t5);
+	fp12_null(t6);
+	fp12_null(r0);
+	fp12_null(r1);
+	bn_null(x);
+
+	RLC_TRY {
+		fp12_new(t0);
+		fp12_new(t1);
+		fp12_new(t2);
+		fp12_new(t3);
+		fp12_new(t4);
+		fp12_new(t5);
+		fp12_new(t6);
+		fp12_new(r0);
+		fp12_new(r1);
+		bn_new(x);
+
+		fp_prime_get_par(x);
+		b = fp_prime_get_par_sps(&l);
+
+		/* First, compute m = f^(p^6 - 1)(p^2 + 1). */
+		fp12_conv_cyc(c, a);
+
+		/* Now compute m^((p^4 - p^2 + 1) / r) using addition chain method. */
+		fp12_frb(r0, c, 1);
+		fp12_frb(r1, c, 2);
+		fp12_frb(t0, c, 3);
+		fp12_mul(t0, t0, r0);
+		fp12_mul(t0, t0, r1);
+
+		fp12_copy(t1, c);
+
+		fp12_exp_cyc_sps(t4, c, b, l, RLC_POS);
+		fp12_exp_cyc_sps(t5, t4, b, l, RLC_POS);
+		fp12_exp_cyc_sps(t6, t5, b, l, RLC_POS);
+
+		fp12_frb(t3, t4, 1);
+		fp12_frb(t2, t5, 2);
+		fp12_frb(r0, t6, 1);
+		fp12_mul(t6, t6, r0);
+		fp12_frb(r0, t5, 1);
+		fp12_mul(t4, t4, r0);
+
+		fp12_inv_cyc(t1, t1);
+		fp12_inv_cyc(t3, t3);
+		fp12_inv_cyc(t4, t4);
+		fp12_inv_cyc(t5, t5);
+		fp12_inv_cyc(t6, t6);
+
+		fp12_sqr_cyc(r0, t6);
+		fp12_mul(r0, r0, t4);
+		fp12_mul(r0, r0, t5);
+		fp12_mul(r1, t5, t3);
+		fp12_mul(r1, r0, r1);
+		fp12_mul(r0, r0, t2);
+		fp12_sqr_cyc(r1, r1);
+		fp12_mul(r1, r1, r0);
+		fp12_sqr_cyc(r1, r1);
+		fp12_mul(r0, r1, t0);
+		fp12_mul(r1, r1, t1);
+		fp12_sqr_cyc(r1, r1);
+		fp12_mul(c, r0, r1);
+	}
+	RLC_CATCH_ANY {
+		RLC_THROW(ERR_CAUGHT);
+	}
+	RLC_FINALLY {
+		fp12_free(t0);
+		fp12_free(t1);
+		fp12_free(t2);
+		fp12_free(t3);
+		fp12_free(t4);
+		fp12_free(t5);
+		fp12_free(t6);
+		fp12_free(r0);
+		fp12_free(r1);
+		bn_free(x);
+	}
+}
+
+/**
  * Computes the final exponentiation of a pairing defined over a
  * Barreto-Lynn-Scott curve.
  *
@@ -241,8 +340,14 @@ static void pp_exp_b12(fp12_t c, fp12_t a) {
 void pp_exp_k12(fp12_t c, fp12_t a) {
 	switch (ep_curve_is_pairf()) {
 		case EP_BN:
-			pp_exp_bn(c, a);
-			break;
+			switch (ep_param_get()) {
+				case SM9_P256:
+					pp_exp_sm9(c, a);
+					break;
+				default:
+					pp_exp_bn(c, a);
+					break;
+			}
 		case EP_B12:
 			pp_exp_b12(c, a);
 			break;


### PR DESCRIPTION
1. RELIC has already supported the SM9 standard (the Chinese national cryptography standard for Identity Based Cryptography), but the pairing result is not consistent with the exmaple given in the SM9 standard. Therefore, I modified the final exponentiation part for SM9 and added `pp_exp_sm9()` to `relic_pp_exp_k12.c`, so that the pairing result is consitent.
2. Add support for SM2 standard (the Chinese national cryptography standard for elliptic curve based cryptography).