### PR TITLE
Instead of hoping for the correct number of bits, fix the largest bit

### DIFF
--- a/src/bn/relic_bn_prime.c
+++ b/src/bn/relic_bn_prime.c
@@ -520,32 +520,32 @@ void bn_gen_prime_stron(bn_t a, size_t bits) {
 #endif
 
 int bn_gen_prime_factor(bn_t a, bn_t b, size_t abits, size_t bbits) {
-	bn_t t;
+	bn_t t, u;
 	int result = RLC_OK;
 
     if (! (bbits>abits) ) {
 		return RLC_ERR;
     }
 
-    bn_null(t);
+    bn_null(t); bn_null(u);
 
     RLC_TRY {
         bn_new(t);
 		bn_gen_prime(a, abits);
+        bn_set_dig(t,1);
+        bn_lsh(t, t, bbits - bn_bits(a) - 1);
         do {
-            bn_rand(t, RLC_POS, bbits - bn_bits(a));
-            do {
-                bn_mul(b, a, t);
-                bn_add_dig(b, b, 1);
-                bn_add_dig(t, t, 1);
-            } while(! bn_is_prime(b));
-        } while (bn_bits(b) != bbits);
+            bn_rand(u, RLC_POS, bbits - bn_bits(a) - 1);
+            bn_add(u, u, t);
+            bn_mul(b, a, u);
+            bn_add_dig(b, b, 1);
+        } while ((bn_bits(b) != bbits) || (! bn_is_prime(b)));
     }
     RLC_CATCH_ANY {
 		result = RLC_ERR;
     }
     RLC_FINALLY {
-        bn_free(t);
+        bn_free(t); bn_free(u);
     }
 
     return result;


### PR DESCRIPTION
This improves bn_gen_prime_factor, generating a prime with large (p-1) prime factor.
Once the large prime factor, a, is found, 
- the previous version:
    - tries to find primes p of the form 1 + a * (t+u) with random t and increasing u from 0
    - until p is prime and of the desired size
- the new version:
    - fixes t to be a power of two, and makes random selections of u's, so that p is almost always of the desired size
    - until p is prime and of the desired size
- the new version can be an order of magnitude faster on average, but also for the worst cases.