### PR TITLE
Fix Linking of multiple builds with MULTI on

### DIFF
--- a/demo/link-test/Makefile
+++ b/demo/link-test/Makefile
@@ -7,11 +7,11 @@ all: type1 type3
 
 type1:
 	mkdir -p target-type1
-	cd target-type1; cmake -DLABEL=type1 ${RELIC_ROOT}; ${RELIC_ROOT}/preset/gmp-pbc-ss1536.sh ${RELIC_ROOT}; make && make install
+	cd target-type1; cmake -DLABEL=type1 -DMULTI=PTHREAD ${RELIC_ROOT}; ${RELIC_ROOT}/preset/gmp-pbc-ss1536.sh ${RELIC_ROOT}; make && make install
 
 type3:
 	mkdir -p target-type3
-	cd target-type3; cmake -DLABEL=type3 ${RELIC_ROOT}; ${RELIC_ROOT}/preset/x64-pbc-bls12-381.sh ${RELIC_ROOT}; make && make install
+	cd target-type3; cmake -DLABEL=type3 -DMULTI=PTHREAD ${RELIC_ROOT}; ${RELIC_ROOT}/preset/x64-pbc-bls12-381.sh ${RELIC_ROOT}; make && make install
 
 clean:
 	rm -rf target-* *.o test

--- a/include/relic_label.h
+++ b/include/relic_label.h
@@ -49,6 +49,11 @@
 #undef core_ctx
 #define core_ctx      RLC_PREFIX(core_ctx)
 
+#undef core_thread_initializer
+#define core_thread_initializer      RLC_PREFIX(core_thread_initializer)
+#undef core_init_ptr
+#define core_init_ptr      RLC_PREFIX(core_init_ptr)
+
 #undef core_init
 #undef core_clean
 #undef core_get


### PR DESCRIPTION
When linking multiple Relic Builds with MULTI Macro for both libraries, building will result in the following error: 

```
/usr/bin/ld: /usr/local/lib/librelic_s_type3.a(relic_core.c.o):(.bss+0x8): multiple definition of `core_thread_initializer'; /usr/local/lib/librelic_s_type1.a(relic_core.c.o):(.bss+0x8): first defined here
/usr/bin/ld: /usr/local/lib/librelic_s_type3.a(relic_core.c.o):(.bss+0x0): multiple definition of `core_init_ptr'; /usr/local/lib/librelic_s_type1.a(relic_core.c.o):(.bss+0x0): first defined here
```

I have modified the `link-test` demo to reproduce this error, and created macros for the affected symbols. 