### PR TITLE
Fix 1 typo in comment section of relic_util.h

### DIFF
--- a/include/relic_util.h
+++ b/include/relic_util.h
@@ -260,7 +260,7 @@
 /*============================================================================*/
 
 /**
- * Toggle endianess of a digit.
+ * Toggle endianness of a digit.
  */
 uint32_t util_conv_endian(uint32_t i);
 


### PR DESCRIPTION
Fix: 1 typo in comment section of relic_util.h.  `endianess`  ->  `endianness`