### PR TITLE
demo/paillier: fix example compilation errors

### DIFF
--- a/preset/gmp-paillier-4096.sh
+++ b/preset/gmp-paillier-4096.sh
@@ -1,2 +1,2 @@
 #!/bin/sh 
-cmake -DCHECK=off -DARITH=gmp -DBN_PRECI=4096 -DALLOC=DYNAMIC -DCFLAGS="-O3 -march=native -mtune=native -fomit-frame-pointer" -DWITH="DV;BN;MD;CP" -DSHLIB=off $1
+cmake -DCHECK=off -DARITH=gmp -DBN_PRECI=4096 -DALLOC=DYNAMIC -DCFLAGS="-O3 -march=native -mtune=native -fomit-frame-pointer" -DWITH="DV;BN;MD;CP;EP;FP;" -DSHLIB=off $1


### PR DESCRIPTION
### Contribution description

This PR fixes compilation error of `demo/general-paillier` example code. 

### Testing procedure

Without this PR compilation of example `demo/general-paillier` ends with error:

```
[ 74%] Linking C executable ../bin/test_bn
/usr/bin/ld: ../lib/librelic_s.a(relic_bn_rec.c.o): in function `bn_rec_sac':
relic_bn_rec.c:(.text+0x26db): undefined reference to `fp_prime_get_par'
/usr/bin/ld: relic_bn_rec.c:(.text+0x271c): undefined reference to `ep_curve_is_pairf'
/usr/bin/ld: relic_bn_rec.c:(.text+0x2931): undefined reference to `fp_prime_get_par'
collect2: error: ld returned 1 exit status
```

With this PR compilation ends with success. Error was observed and solution tested on Debian and Ubuntu distributions.