### PR TITLE
gitignore: add demo executables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,14 @@ include/relic_conf.h
 install_manifest.txt
 
 src/low/fiat/*.c
+
+demo/cert-input/test-bench
+demo/ers-etrs/test-bench
+demo/general-paillier/test
+demo/psi-client-server/receiver
+demo/psi-client-server/sender
+demo/psi-client-server/test-bench
+demo/public-stats/data.csv
+demo/public-stats/data_04_13.csv
+demo/public-stats/main
+demo/tweedledum/main


### PR DESCRIPTION
### Contribution description

This PR adds all executables and temporary files used by test programs from `demo` directory to the `.gitignore` file.

### Testing procedure

Without this PR after compilation of test programs from `demo` directory git starts to track some unnecessary files:

```
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	demo/cert-input/test-bench
	demo/general-paillier/test
	demo/public-stats/data.csv
	demo/public-stats/data_04_13.csv
	demo/public-stats/main
	demo/tweedledum/main

nothing added to commit but untracked files present (use "git add" to track)
```

with this PR these files are not tracked by git:

```
$ git status
On branch gitignore-demo-executables
Your branch is up to date with 'origin/gitignore-demo-executables'.

nothing to commit, working tree clean
```