### PR TITLE
Fix typo in bench/bench_pp.c.

### DIFF
--- a/bench/bench_pp.c
+++ b/bench/bench_pp.c
@@ -1512,7 +1512,7 @@ int main(void) {
 		pairing18();
 	}
 
-	if (ep_curve_embed() == 48) {
+	if (ep_curve_embed() == 24) {
 		pairing24();
 	}
 


### PR DESCRIPTION
This fixes a typo in `bench/bench_pp.c`.