### PR TITLE
Fix arm-asm-254 toolchain compatibility for Cortex-M4.

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -19,7 +19,7 @@ jobs:
         dry-run: false
         language: c++
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts

--- a/src/low/arm-asm-254/relic_fp_add_low.s
+++ b/src/low/arm-asm-254/relic_fp_add_low.s
@@ -28,7 +28,7 @@
 #define RLC_GT	1
 
 .syntax unified
-.arch armv7-a
+.arch armv7e-m
 
 /*============================================================================*/
 /* Public definitions                                                         */
@@ -276,7 +276,9 @@ fp_addm_low2:
 	SBCS r10, r10, r3
 
 	/**** Setima iteracao ****/
-	SBCS r11, r11, #0x40000001
+	MOVW r3, #0x0001
+	MOVT r3, #0x4000
+	SBCS r11, r11, r3
 
 	/**** Oitava iteracao ****/
 	MOVW r3, #0x6482
@@ -315,7 +317,9 @@ fp_addm_low2:
 	ADCS r10, r10, r4
 
 	/**** Setima iteracao ****/
-	AND  r4, r3, #0x40000001
+	MOVW r4, #0x0001
+	MOVT r4, #0x4000
+	AND  r4, r4, r3
 	ADCS r11, r11, r4
 
 	/**** Oitava iteracao ****/
@@ -394,7 +398,9 @@ fp_addm_low:
 	BLO LESS_THAN
 
 	/**** Segunda iteracao ****/
-	CMP r11, #0x40000001
+	MOVW r3, #0x0001
+	MOVT r3, #0x4000
+	CMP r11, r3
 	BHI GREATER_THAN_OR_EQUAL
 	BLO LESS_THAN
 
@@ -464,7 +470,9 @@ GREATER_THAN_OR_EQUAL:
 	STR r10, [r0, #20]
 
 	/**** Setima iteracao ****/
-	SBCS r11, r11, #0x40000001
+	MOVW r3, #0x0001
+	MOVT r3, #0x4000
+	SBCS r11, r11, r3
 	STR r11, [r0, #24]
 
 	/**** Oitava iteracao ****/
@@ -584,7 +592,9 @@ fp_subm_low2:
 	ADCNES r10, r10, r3
 
 	/**** Setima iteracao ****/
-	ADCNES r11, r11, #0x40000001
+	MOVW r3, #0x0001
+	MOVT r3, #0x4000
+	ADCNES r11, r11, r3
 
 	/**** Oitava iteracao ****/
 	MOVW r3, #0x6482
@@ -704,7 +714,9 @@ IS_ONE:
 	STR r10, [r0, #20]
 
 	/**** Setima iteracao ****/
-	ADCS r11, r11, #0x40000001
+	MOVW r3, #0x0001
+	MOVT r3, #0x4000
+	ADCS r11, r11, r3
 	STR r11, [r0, #24]
 
 	/**** Oitava iteracao ****/

--- a/src/low/arm-asm-254/relic_fp_mul_low.s
+++ b/src/low/arm-asm-254/relic_fp_mul_low.s
@@ -24,7 +24,7 @@
 #include "relic_fp_low.h"
 
 .syntax unified
-.arch armv7-a
+.arch armv7e-m
 
 .global fp_muln_low
 

--- a/src/low/arm-asm-254/relic_fp_rdc_low.s
+++ b/src/low/arm-asm-254/relic_fp_rdc_low.s
@@ -24,7 +24,7 @@
 #include "relic_fp_low.h"
 
 .syntax unified
-.arch armv7-a
+.arch armv7e-m
 
 /*============================================================================*/
 /* Public definitions                                                         */


### PR DESCRIPTION
# Fix arm-asm-254 toolchain compatibility for Cortex-M4

## Summary

The hand-written assembly backend `arm-asm-254` no longer assembles with modern
arm-none-eabi-gcc / binutils (verified failing on binutils 2.42, broke around
2.39+). This PR makes minimal changes to restore buildability without altering
the algorithms or instruction selection.

## The bug

Two distinct issues in `src/low/arm-asm-254/`:

**1. Architecture profile mismatch (3 files).** The `.arch armv7-a` directive
is incorrect for the actual target hardware (Cortex-M4 = `armv7e-m`). Modern
binutils enforces this and rejects Thumb-2 IT-block encodings used elsewhere
in the file:

    Error: selected processor does not support `it eq' in Thumb mode

**2. Invalid Thumb-2 modified immediate (1 file).** Six instructions in
`relic_fp_add_low.s` use `#0x40000001` as a fused immediate. This value
(bit 30 + bit 0) cannot be encoded as a Thumb-2 modified immediate, which
only admits 8-bit values rotated or replicated in specific patterns. Modern
binutils reports:

    Error: invalid constant (40000001) after fixup

`#0x40000001` is limb 6 of the BN-254 prime field modulus when split into
eight 32-bit little-endian limbs.

## The fix

### Architecture flag (3 files)

    -.arch armv7-a
    +.arch armv7e-m

Cortex-M4 is `armv7e-m`. None of the instructions used in these files require
A-profile features that `armv7e-m` lacks.

### Immediate constant rewrite (`relic_fp_add_low.s`)

Each of the six `#0x40000001` sites is rewritten to load the constant via
`MOVW`/`MOVT` into a scratch register before use, following the convention
already used by adjacent iterations of the same unrolled loops:

    -       SBCS r11, r11, #0x40000001
    +       MOVW r3, #0x0001
    +       MOVT r3, #0x4000
    +       SBCS r11, r11, r3

Splitting `0x40000001` as `MOVW r?, #0x0001` (low 16 bits) + `MOVT r?, #0x4000`
(high 16 bits) yields the same value in the register.

## Register liveness

The choice of scratch register is justified per-site:

- **Lines 279, 467, 587, 707** (4 sites, all SBCS/ADCS/ADCNES) use `r3`. The
  next iteration in each loop already writes `r3` with its own MOVW/MOVT
  before reading, so `r3` carries no live value across the patched window.

- **Line 318** uses `r4` instead of `r3`. At this site `r3` holds a carry
  mask that must remain live for the trailing `AND`. The adjacent iterations
  (sixth and eighth in the same loop) already use `r4` as their scratch in
  exactly the same pattern. `AND` is commutative, so `AND r4, r4, r3`
  produces the same value as the original `AND r4, r3, #0x40000001`.

- **Line 397** uses `r3`. This is a `CMP`, which writes only flags. The two
  branch targets (`GREATER_THAN_OR_EQUAL` and `LESS_THAN`) do not read `r3`
  before rewriting it; the fall-through path immediately writes `r3` with
  `MOVW`/`MOVT`.

## Correctness conditions

Two non-obvious correctness conditions hold:

**CPSR preservation.** `MOVW`, `MOVT`, and (plain) `AND` do not modify
condition flags. The carry flag flowing in from the prior `SBCS`/`ADCS` is
preserved across the inserted prologue, so the patched arithmetic instruction
consumes the same `C` bit it would have consumed without the patch.

**IT-block scope at line 587.** The conditional `ADCNES` instructions in
`fp_subm_low2` use legacy infix-conditional syntax. GAS auto-generates a
single-instruction `IT NE` block for each such infix instruction, so each
`ADCNES` is its own atomic `IT NE; ADCS` pair. Inserting unconditional
`MOVW`/`MOVT` between two such pairs is safe — the IT scope never spans them.
Empirically confirmed by disassembling the binutils 2.42 output: each
`ADCNES` gets its own `it ne` prefix, and the inserted `MOVW`/`MOVT` sit
outside any IT scope.

## Verification

- Builds cleanly with `arm-none-eabi-gcc 13.2.1` and `binutils 2.42`.
- RELIC's PC test suite (`test_fp`, `test_fpx`, `test_pp`) passes.
- On STM32F407 hardware with `ARITH=arm-asm-254`:
  - 8011 mathematical regression test cases pass.
  - Bilinearity check `e([2]P, Q) == e(P, Q)^2` passes.
  - End-to-end pairing-based protocol (AmorE) runs 62 rounds (61 honest +
    1 malicious) without a single arithmetic error. Per-round amortized cost
    on Cortex-M4 @ 168 MHz: 379 ms.

The `arm-asm-254` backend is not exercised by the existing CI workflows
(which test `gmp`, `gmp-sec`, and `easy`), so no automated coverage was
broken or reproduced.

## Reference implementation

A reference application that exercises `arm-asm-254` end-to-end on STM32F407
(with full validation against this fix) is available at:
https://github.com/kobibr/amore-bn254-cortex-m4